### PR TITLE
Update Hierarchization

### DIFF
--- a/distributedcombigrid/examples/combi_example/combi_example.cpp
+++ b/distributedcombigrid/examples/combi_example/combi_example.cpp
@@ -30,10 +30,9 @@
 using namespace combigrid;
 
 // this is necessary for correct function of task serialization
+#include "sgpp/distributedcombigrid/utils/BoostExports.hpp"
 BOOST_CLASS_EXPORT(TaskExample)
-BOOST_CLASS_EXPORT(StaticFaults)
-BOOST_CLASS_EXPORT(WeibullFaults)
-BOOST_CLASS_EXPORT(FaultCriterion)
+
 int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
 

--- a/distributedcombigrid/examples/combi_example_faults/combi_example_faults.cpp
+++ b/distributedcombigrid/examples/combi_example_faults/combi_example_faults.cpp
@@ -35,12 +35,8 @@
 using namespace combigrid;
 
 // this is necessary for correct function of task serialization
+#include "sgpp/distributedcombigrid/utils/BoostExports.hpp"
 BOOST_CLASS_EXPORT(TaskExample)
-BOOST_CLASS_EXPORT(StaticFaults)
-BOOST_CLASS_EXPORT(WeibullFaults)
-
-BOOST_CLASS_EXPORT(FaultCriterion)
-
 
 int main(int argc, char** argv) {
   simft::Sim_FT_MPI_Init(&argc, &argv);

--- a/distributedcombigrid/examples/gene_distributed/src/manager.cpp
+++ b/distributedcombigrid/examples/gene_distributed/src/manager.cpp
@@ -30,12 +30,8 @@
 
 using namespace combigrid;
 // this is necessary for correct function of task serialization
+#include "sgpp/distributedcombigrid/utils/BoostExports.hpp"
 BOOST_CLASS_EXPORT(GeneTask)
-BOOST_CLASS_EXPORT(StaticFaults)
-BOOST_CLASS_EXPORT(WeibullFaults)
-
-BOOST_CLASS_EXPORT(FaultCriterion)
-
 
 // helper funtion to read a bool vector from string
 inline std::vector<bool>& operator>>(std::string str, std::vector<bool>& vec) {

--- a/distributedcombigrid/examples/gene_distributed_linear/src/manager.cpp
+++ b/distributedcombigrid/examples/gene_distributed_linear/src/manager.cpp
@@ -30,12 +30,8 @@
 
 using namespace combigrid;
 // this is necessary for correct function of task serialization
+#include "sgpp/distributedcombigrid/utils/BoostExports.hpp"
 BOOST_CLASS_EXPORT(GeneTask)
-BOOST_CLASS_EXPORT(StaticFaults)
-BOOST_CLASS_EXPORT(WeibullFaults)
-
-BOOST_CLASS_EXPORT(FaultCriterion)
-
 
 // helper funtion to read a bool vector from string
 inline std::vector<bool>& operator>>(std::string str, std::vector<bool>& vec) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -672,15 +672,27 @@ class DistributedFullGrid {
 
   // returns level of a global 1d index
   inline LevelType getLevel(DimType d, IndexType idx1d) const {
-    IndexVector givec(dim_, 0);
-    givec[d] = idx1d;
-    IndexType idx = getGlobalLinearIndex(givec);
+    // IndexVector givec(dim_, 0);
+    // givec[d] = idx1d;
+    // IndexType idx = getGlobalLinearIndex(givec);
+    // LevelVector levels(dim_);
+    // IndexVector tmp(dim_);
+    // getGlobalLI(idx, levels, tmp);
+    // return levels[d];
 
-    LevelVector levels(dim_);
-    IndexVector tmp(dim_);
-    getGlobalLI(idx, levels, tmp);
-
-    return levels[d];
+    // get level of idx1d by rightmost set bit
+    // (e.g., all points on the finest level already have a 1 at the rightmost bit)
+    if (idx1d == 0) {
+      return 0;
+    }
+    const LevelType lmax = this->getLevels()[d];
+    // auto set_bit = idx1d & ~(idx1d-1);
+    // LevelType l = lmax - log2(set_bit);
+    // builtin is fast and should work with gcc and clang
+    // if it is not available, use the one above (at a slight performance hit)
+    // or c++20's std::countr_zero
+    LevelType l = lmax - __builtin_ctz(idx1d);
+    return l;
   }
 
   // get 1d index of LeftPredecessor of a point

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -1064,9 +1064,9 @@ class DistributedFullGrid {
     }
 
     // auto indexAssignment = getLocalFGIndexToLocalSGPointerList();
-    #ifdef DEBUG_OUTPUT
-      MASTER_EXCLUSIVE_SECTION { std::cout << "is this where " << indexAssignment[0] << "?\n"; }
-    #endif
+    // #ifdef DEBUG_OUTPUT
+    //   MASTER_EXCLUSIVE_SECTION { std::cout << "is this where " << indexAssignment[0] << "?\n"; }
+    // #endif
 
     bool anythingWasAdded = false;
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -770,6 +770,23 @@ class DistributedFullGrid {
     return rank;
   }
 
+  inline std::vector<RankType> getAllMyPoleNeighborRanks(DimType dim) const {
+    auto ranks = std::vector<RankType>();
+    auto myPartitionCoords = std::vector<int>();
+    this->getPartitionCoords(myPartitionCoords);
+    for (int i = 0; i < myPartitionCoords[dim]; ++i) {
+      auto neighborPartitionCoords = myPartitionCoords;
+      neighborPartitionCoords[dim] = i;
+      ranks.push_back(getRank(neighborPartitionCoords));
+    }
+    for (int i = myPartitionCoords[dim] + 1; i < procs_[dim]; ++i) {
+      auto neighborPartitionCoords = myPartitionCoords;
+      neighborPartitionCoords[dim] = i;
+      ranks.push_back(getRank(neighborPartitionCoords));
+    }
+    return ranks;
+  }
+
   inline RankType getRank(IndexVector& partitionCoords) const {
     std::vector<int> partitionCoordsInt(partitionCoords.begin(), partitionCoords.end());
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -680,6 +680,9 @@ class DistributedFullGrid {
     // getGlobalLI(idx, levels, tmp);
     // return levels[d];
 
+    if (!this->hasBoundaryPoints_[d]) {
+      ++idx1d;
+    }
     // get level of idx1d by rightmost set bit
     // (e.g., all points on the finest level already have a 1 at the rightmost bit)
     if (idx1d == 0) {
@@ -691,7 +694,7 @@ class DistributedFullGrid {
     // builtin is fast and should work with gcc and clang
     // if it is not available, use the one above (at a slight performance hit)
     // or c++20's std::countr_zero
-    LevelType l = lmax - __builtin_ctz(idx1d);
+    LevelType l = lmax - static_cast<LevelType>(__builtin_ctzl(static_cast<unsigned long>(idx1d)));
     return l;
   }
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -480,7 +480,7 @@ class DistributedFullGrid {
   inline IndexType getNrLocalElements() const { return nrLocalElements_; }
 
   /** number of points per dimension i */
-  inline IndexType length(int i) const { return nrPoints_[i]; }
+  inline IndexType length(DimType i) const { return nrPoints_[i]; }
 
   /** vector of flags to show if the dimension has boundary points*/
   inline const std::vector<bool>& returnBoundaryFlags() const { return hasBoundaryPoints_; }
@@ -671,7 +671,7 @@ class DistributedFullGrid {
   }
 
   // returns level of a global 1d index
-  inline LevelType getLevel(DimType d, IndexType idx1d) {
+  inline LevelType getLevel(DimType d, IndexType idx1d) const {
     IndexVector givec(dim_, 0);
     givec[d] = idx1d;
     IndexType idx = getGlobalLinearIndex(givec);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -885,7 +885,7 @@ class DistributedFullGrid {
 
   // get 1d index of LeftPredecessor of a point
   // returns negative number if point has no left predecessor
-  inline IndexType getLeftPredecessor(DimType d, IndexType idx1d) {
+  inline IndexType getLeftPredecessor(DimType d, IndexType idx1d) const {
     LevelType l = getLevel(d, idx1d);
 
     // boundary points
@@ -897,7 +897,7 @@ class DistributedFullGrid {
     return lpidx;
   }
 
-  inline IndexType getRightPredecessor(DimType d, IndexType idx1d) {
+  inline IndexType getRightPredecessor(DimType d, IndexType idx1d) const {
     LevelType l = getLevel(d, idx1d);
 
     // boundary points
@@ -916,7 +916,7 @@ class DistributedFullGrid {
 
   // get coordinates of the partition which contains the point specified
   // by the global index vector
-  inline void getPartitionCoords(IndexVector& globalAxisIndex, IndexVector& partitionCoords) {
+  inline void getPartitionCoords(IndexVector& globalAxisIndex, IndexVector& partitionCoords) const {
     partitionCoords.resize(dim_);
 
     for (DimType d = 0; d < dim_; ++d) {
@@ -955,6 +955,10 @@ class DistributedFullGrid {
     return rank;
   }
 
+  /**
+   * @brief get a vector containing the ranks of all my cartesian neighboring
+   *        ranks in dimension dim (not only the direct neighbors, all of them)
+   */
   inline std::vector<RankType> getAllMyPoleNeighborRanks(DimType dim) const {
     auto ranks = std::vector<RankType>();
     auto myPartitionCoords = std::vector<int>();
@@ -1024,20 +1028,10 @@ class DistributedFullGrid {
         IndexVector subsizes = this->getUpperBounds(r) - this->getLowerBounds(r);
         IndexVector starts = this->getLowerBounds(r);
 
-        // we store our data in c format, i.e. first dimension is the innermost
-        // dimension. however, we access our data in fortran notation, with the
-        // first index in indexvectors being the first dimension.
-        // to comply with an ordering that mpi understands, we have to reverse
-        // our index vectors
-        // also we have to use int as datatype
         std::vector<int> csizes(sizes.begin(), sizes.end());
         std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
         std::vector<int> cstarts(starts.begin(), starts.end());
-        // if (!reverseOrderingDFGPartitions) { // not sure why, but this produces the wrong results
-        //   csizes.assign(sizes.begin(), sizes.end());
-        //   csubsizes.assign(subsizes.begin(), subsizes.end());
-        //   cstarts.assign(starts.begin(), starts.end());
-        // }
+
 
         // create subarray view on data
         MPI_Datatype mysubarray;
@@ -1748,13 +1742,6 @@ class DistributedFullGrid {
     IndexVector sizes = getGlobalSizes();
     IndexVector subsizes = getUpperBounds() - getLowerBounds();
     IndexVector starts = getLowerBounds();
-
-    // we store our data in c format, i.e. first dimension is the innermost
-    // dimension. however, we access our data in fortran notation, with the
-    // first index in indexvectors being the first dimension.
-    // to comply with an ordering that mpi understands, we have to reverse
-    // our index vectors
-    // also we have to use int as datatype
     std::vector<int> csizes(sizes.begin(), sizes.end());
     std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
     std::vector<int> cstarts(starts.begin(), starts.end());
@@ -1826,12 +1813,6 @@ class DistributedFullGrid {
     IndexVector subsizes = getUpperBounds() - getLowerBounds();
     IndexVector starts = getLowerBounds();
 
-    // we store our data in c format, i.e. first dimension is the innermost
-    // dimension. however, we access our data in fortran notation, with the
-    // first index in indexvectors being the first dimension.
-    // to comply with an ordering that mpi understands, we have to reverse
-    // our index vectors
-    // also we have to use int as datatype
     std::vector<int> csizes(sizes.begin(), sizes.end());
     std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
     std::vector<int> cstarts(starts.begin(), starts.end());

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGridNonUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGridNonUniform.hpp
@@ -708,9 +708,9 @@ class DistributedFullGridNonUniform {
         // to comply with an ordering that mpi understands, we have to reverse
         // our index vectors
         // also we have to use int as datatype
-        std::vector<int> csizes(sizes.rbegin(), sizes.rend());
-        std::vector<int> csubsizes(subsizes.rbegin(), subsizes.rend());
-        std::vector<int> cstarts(starts.rbegin(), starts.rend());
+        std::vector<int> csizes(sizes.begin(), sizes.end());
+        std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
+        std::vector<int> cstarts(starts.begin(), starts.end());
         if (!reverseOrderingDFGPartitions) {
           assert(false && "this is not adapted to normal ordering of DFG partitions yet");
         }
@@ -718,7 +718,7 @@ class DistributedFullGridNonUniform {
         // create subarray view on data
         MPI_Datatype mysubarray;
         MPI_Type_create_subarray(static_cast<int>(this->getDimension()), &csizes[0], &csubsizes[0],
-                                 &cstarts[0], MPI_ORDER_C, this->getMPIDatatype(), &mysubarray);
+                                 &cstarts[0], MPI_ORDER_FORTRAN, this->getMPIDatatype(), &mysubarray);
         MPI_Type_commit(&mysubarray);
         subarrayTypes.push_back(mysubarray);
 
@@ -1217,9 +1217,9 @@ class DistributedFullGridNonUniform {
         // to comply with an ordering that mpi understands, we have to reverse
         // our index vectors
         // also we have to use int as datatype
-        std::vector<int> csizes(sizes.rbegin(), sizes.rend());
-        std::vector<int> csubsizes(subsizes.rbegin(), subsizes.rend());
-        std::vector<int> cstarts(starts.rbegin(), starts.rend());
+        std::vector<int> csizes(sizes.begin(), sizes.end());
+        std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
+        std::vector<int> cstarts(starts.begin(), starts.end());
         if (!reverseOrderingDFGPartitions) {
           assert(false && "this is not adapted to normal ordering of DFG partitions yet");
         }
@@ -1227,7 +1227,7 @@ class DistributedFullGridNonUniform {
         // create subarray view on data
         MPI_Datatype mysubarray;
         MPI_Type_create_subarray(int(this->getDimension()), &csizes[0], &csubsizes[0], &cstarts[0],
-                                 MPI_ORDER_C, this->getMPIDatatype(), &mysubarray);
+                                 MPI_ORDER_FORTRAN, this->getMPIDatatype(), &mysubarray);
         MPI_Type_commit(&mysubarray);
         subarrayTypes.push_back(mysubarray);
 
@@ -1771,9 +1771,9 @@ class DistributedFullGridNonUniform {
         // to comply with an ordering that mpi understands, we have to reverse
         // our index vectors
         // also we have to use int as datatype
-        std::vector<int> csizes(sizes.rbegin(), sizes.rend());
-        std::vector<int> csubsizes(subsizes.rbegin(), subsizes.rend());
-        std::vector<int> cstarts(starts.rbegin(), starts.rend());
+        std::vector<int> csizes(sizes.begin(), sizes.end());
+        std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
+        std::vector<int> cstarts(starts.begin(), starts.end());
         if (!reverseOrderingDFGPartitions) {
           assert(false && "this is not adapted to normal ordering of DFG partitions yet");
         }
@@ -1781,7 +1781,7 @@ class DistributedFullGridNonUniform {
         // create subarray view on data
         MPI_Datatype mysubarray;
         MPI_Type_create_subarray(int(this->getDimension()), &csizes[0], &csubsizes[0], &cstarts[0],
-                                 MPI_ORDER_C, this->getMPIDatatype(), &mysubarray);
+                                 MPI_ORDER_FORTRAN, this->getMPIDatatype(), &mysubarray);
 
         MPI_Type_commit(&mysubarray);
         subsp.subarrayTypes_.push_back(mysubarray);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGridNonUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGridNonUniform.hpp
@@ -95,7 +95,7 @@ class DistributedFullGridNonUniform {
 
     // set the basis function for the full grid
     if (basis == NULL)
-      basis_ = LinearBasisFunction::getDefaultBasis();
+      basis_ = nullptr; //LinearBasisFunction::getDefaultBasis();
     else
       basis_ = basis;
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGridNonUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGridNonUniform.hpp
@@ -702,18 +702,9 @@ class DistributedFullGridNonUniform {
         IndexVector subsizes = this->getUpperBounds(r) - this->getLowerBounds(r);
         IndexVector starts = this->getLowerBounds(r);
 
-        // we store our data in c format, i.e. first dimension is the innermost
-        // dimension. however, we access our data in fortran notation, with the
-        // first index in indexvectors being the first dimension.
-        // to comply with an ordering that mpi understands, we have to reverse
-        // our index vectors
-        // also we have to use int as datatype
         std::vector<int> csizes(sizes.begin(), sizes.end());
         std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
         std::vector<int> cstarts(starts.begin(), starts.end());
-        if (!reverseOrderingDFGPartitions) {
-          assert(false && "this is not adapted to normal ordering of DFG partitions yet");
-        }
 
         // create subarray view on data
         MPI_Datatype mysubarray;
@@ -1211,18 +1202,9 @@ class DistributedFullGridNonUniform {
 
         if (ssize == 0) continue;
 
-        // we store our data in c format, i.e. first dimension is the innermost
-        // dimension. however, we access our data in fortran notation, with the
-        // first index in indexvectors being the first dimension.
-        // to comply with an ordering that mpi understands, we have to reverse
-        // our index vectors
-        // also we have to use int as datatype
         std::vector<int> csizes(sizes.begin(), sizes.end());
         std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
         std::vector<int> cstarts(starts.begin(), starts.end());
-        if (!reverseOrderingDFGPartitions) {
-          assert(false && "this is not adapted to normal ordering of DFG partitions yet");
-        }
 
         // create subarray view on data
         MPI_Datatype mysubarray;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/FullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/FullGrid.hpp
@@ -266,7 +266,8 @@ FullGrid<FG_ELEMENT>::FullGrid(DimType dim, LevelType level, bool hasBdrPoints,
                                const BasisFunctionBasis* basis) {
   // set the basis function for the full grid
   if (basis == NULL)
-    basis_ = LinearBasisFunction::getDefaultBasis();
+    //TODO deal with memory leak
+    basis_ = new LinearBasisFunction(); // LinearBasisFunction::getDefaultBasis();
   else
     basis_ = basis;
 
@@ -302,7 +303,8 @@ FullGrid<FG_ELEMENT>::FullGrid(DimType dim, const LevelVector& levels, bool hasB
                                const BasisFunctionBasis* basis) {
   // set the basis function for the full grid
   if (basis == NULL)
-    basis_ = LinearBasisFunction::getDefaultBasis();
+    //TODO deal with memory leak
+    basis_ = new LinearBasisFunction(); // LinearBasisFunction::getDefaultBasis();
   else
     basis_ = basis;
 
@@ -341,7 +343,8 @@ FullGrid<FG_ELEMENT>::FullGrid(DimType dim, const LevelVector& levels,
 
   // set the basis function for the full grid
   if (basis == NULL)
-    basis_ = LinearBasisFunction::getDefaultBasis();
+    //TODO deal with memory leak
+    basis_ = new LinearBasisFunction(); // LinearBasisFunction::getDefaultBasis();
   else
     basis_ = basis;
 
@@ -406,7 +409,8 @@ FullGrid<FG_ELEMENT>::FullGrid(const LevelVector& levels, const SGrid<FG_ELEMENT
 
   // set the basis function for the full grid
   // at the moment we don't have any other basis for sg
-  basis_ = LinearBasisFunction::getDefaultBasis();
+  //TODO deal with memory leak
+  basis_ = new LinearBasisFunction(); // LinearBasisFunction::getDefaultBasis();
 
   gridDomain_ = NULL;
   dim_ = sg2.getDim();

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -600,7 +600,6 @@ void sendAndReceiveIndicesBlock(std::vector<std::set<IndexType>>& send1dIndices,
         auto d = MPI_Aint_diff(addr, dfgStartAddr);
         displacements.push_back(d);
       }
-      assert(displacements[0] == 0);
       // cannot use MPI_Type_create_indexed_block as subarrays may overlap
       MPI_Type_create_hindexed_block(static_cast<int>(indices.size()), 1, displacements.data(),
                                                    mysubarray, &myHBlock);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -609,10 +609,7 @@ static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
 
     if (rpIdx < 0) {
       idx = getNextIndex1d(dfg, dim, idx);
-      continue;
-    }
-
-    if (rpIdx > idxMax) {
+    } else if (rpIdx > idxMax) {
       // get rank which has right predecessor and add to list of indices to recv
       int r = getNeighbor1d(dfg, dim, rpIdx);
       recv1dIndices[r].insert(rpIdx);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -416,7 +416,7 @@ void sendAndReceiveIndices(std::vector<std::set<IndexType>>& send1dIndices,
         int dest = static_cast<int>(r);
         int tag = static_cast<int>(index);
         MPI_Isend(dfg.getData(), 1, mysubarray, dest, tag, dfg.getCommunicator(),
-                [sendcount + k++]);
+                &sendRequests[sendcount + k++]);
 
 #ifdef DEBUG_OUTPUT
         auto rank = dfg.getRank();

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -239,15 +239,6 @@ class LookupTable {
 };
 
 template <typename FG_ELEMENT>
-static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
-                           std::vector<RemoteDataContainer<FG_ELEMENT> >& remoteData);
-
-template <typename FG_ELEMENT>
-static void exchangeData1dDehierarchization(
-    DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
-    std::vector<RemoteDataContainer<FG_ELEMENT> >& remoteData);
-
-template <typename FG_ELEMENT>
 static void checkLeftSuccesors(IndexType checkIdx, IndexType rootIdx, DimType dim,
                                DistributedFullGrid<FG_ELEMENT>& dfg,
                                std::vector<std::set<IndexType>>& OneDIndices);
@@ -273,22 +264,6 @@ static IndexType getFirstIndexOfLevel1d(const DistributedFullGrid<FG_ELEMENT>& d
 template <typename FG_ELEMENT>
 static IndexType getLastIndexOfLevel1d(const DistributedFullGrid<FG_ELEMENT>& dfg, DimType d,
                                         LevelType l);
-
-template <typename FG_ELEMENT>
-static void hierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                      LookupTable<FG_ELEMENT>& lookupTable);
-
-template <typename FG_ELEMENT>
-static void dehierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                        LookupTable<FG_ELEMENT>& lookupTable);
-
-template <typename FG_ELEMENT>
-static void hierarchizeX_opt_noboundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                        LookupTable<FG_ELEMENT>& lookupTable);
-
-template <typename FG_ELEMENT>
-void dehierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                 LookupTable<FG_ELEMENT>& lookupTable, DimType dim);
 
 template <typename FG_ELEMENT>
 static IndexVector getFirstIndexOfEachLevel1d(const DistributedFullGrid<FG_ELEMENT>& dfg, DimType d) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -369,13 +369,6 @@ void sendAndReceiveIndices(std::vector<std::set<IndexType>>& send1dIndices,
         IndexVector subsizes = sizes;
         subsizes[dim] = 1;
 
-        // compute size of subarray for stats
-        {
-          IndexType subarraySize = 1;
-
-          for (DimType i = 0; i < subsizes.size(); ++i) subarraySize *= subsizes[i];
-        }
-
         // start
         IndexVector starts(dfg.getDimension(), 0);
         starts[dim] = lidxvec[dim];

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -376,13 +376,13 @@ void sendAndReceiveIndices(std::vector<std::set<IndexType>>& send1dIndices,
         // note that if we want MPI to use c ordering, for less confusion as we
         // actually store our data in c format, we have to reverse all size and index
         // vectors
-        std::vector<int> csizes(sizes.rbegin(), sizes.rend());
-        std::vector<int> csubsizes(subsizes.rbegin(), subsizes.rend());
-        std::vector<int> cstarts(starts.rbegin(), starts.rend());
+        std::vector<int> csizes(sizes.begin(), sizes.end());
+        std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
+        std::vector<int> cstarts(starts.begin(), starts.end());
 
         // create subarray view on data
         MPI_Type_create_subarray(static_cast<int>(dfg.getDimension()), &csizes[0], &csubsizes[0],
-                                 &cstarts[0], MPI_ORDER_C, dfg.getMPIDatatype(), &mysubarray);
+                                 &cstarts[0], MPI_ORDER_FORTRAN, dfg.getMPIDatatype(), &mysubarray);
         MPI_Type_commit(&mysubarray);
       }
 
@@ -562,13 +562,13 @@ void sendAndReceiveIndicesBlock(std::vector<std::set<IndexType>>& send1dIndices,
     // note that if we want MPI to use c ordering, for less confusion as we
     // actually store our data in c format, we have to reverse all size and index
     // vectors
-    std::vector<int> csizes(sizes.rbegin(), sizes.rend());
-    std::vector<int> csubsizes(subsizes.rbegin(), subsizes.rend());
-    std::vector<int> cstarts(starts.rbegin(), starts.rend());
+    std::vector<int> csizes(sizes.begin(), sizes.end());
+    std::vector<int> csubsizes(subsizes.begin(), subsizes.end());
+    std::vector<int> cstarts(starts.begin(), starts.end());
 
     // create subarray view on data
     MPI_Type_create_subarray(static_cast<int>(dfg.getDimension()), &csizes[0], &csubsizes[0],
-                             &cstarts[0], MPI_ORDER_C, dfg.getMPIDatatype(), &mysubarray);
+                             &cstarts[0], MPI_ORDER_FORTRAN, dfg.getMPIDatatype(), &mysubarray);
     MPI_Type_commit(&mysubarray);
   }
 
@@ -619,7 +619,7 @@ void sendAndReceiveIndicesBlock(std::vector<std::set<IndexType>>& send1dIndices,
         // MPI_Type_size(mysubarrayBlock, &mpiDSize);
         // print info: dest, size, index
         std::cout << "rank " << rank << ": send gindex " << *(indices.begin()) << " + " << displacements << " dest " << dest
-                  // << " data " << *(dfg.getData()) << " " << *(dfg.getData()+1) 
+                  // << " data " << *(dfg.getData()) << " " << *(dfg.getData()+1)
                   // << " full data " << dfg.getElementVector()
                   << " size " << mpiDSize
                   << std::endl;
@@ -684,7 +684,7 @@ void sendAndReceiveIndicesBlock(std::vector<std::set<IndexType>>& send1dIndices,
           MPI_Type_size(myHBlock, &mpiDSize);
           // print info: dest, size, index
           std::cout << "rank " << rank << ": recv gindex " << *(indices.begin()) << " src " << src
-                    << " size: " << bsize << "*" << indices.size() 
+                    << " size: " << bsize << "*" << indices.size()
                     << " size " << mpiDSize
                     << std::endl;
 #endif
@@ -738,6 +738,7 @@ static void exchangeAllData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
   }
 
   sendAndReceiveIndices(send1dIndices, recv1dIndices, dfg, dim, remoteData);
+  // sendAndReceiveIndicesBlock(send1dIndices, recv1dIndices, dfg, dim, remoteData);
 }
 
 // exchange data in dimension dim
@@ -905,6 +906,7 @@ static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
     }
   }
   sendAndReceiveIndices(send1dIndices, recv1dIndices, dfg, dim, remoteData);
+  // sendAndReceiveIndicesBlock(send1dIndices, recv1dIndices, dfg, dim, remoteData);
 }
 
 
@@ -1028,6 +1030,7 @@ static void exchangeData1dDehierarchization(
   }
 
   sendAndReceiveIndices(send1dIndices, recv1dIndices, dfg, dim, remoteData);
+  // sendAndReceiveIndicesBlock(send1dIndices, recv1dIndices, dfg, dim, remoteData);
 }
 
 template <typename FG_ELEMENT>

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -1137,18 +1137,6 @@ static void hierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   IndexVector tmpGlobalIndexVector(dfg.getDimension());
 
   IndexType gstart = dfg.getLowerBounds()[dim];
-
-  // first global index for hierarchization kernel
-  // first nonboundary point
-  IndexType idxstart = gstart;
-
-  if (gstart == 0) idxstart += 1;
-
-  // last global index inside subdomain.
-  // IndexType idxend = dfg.getUpperBounds()[dim] - 1;
-
-  // level of gend
-  // LevelType level_idxend = dfg.getLevel(dim, idxend);
   IndexType linIdxBlockStart;
 
   // loop over all xBlocks of local domain -> linearIndex with stride localndim[0]
@@ -1205,18 +1193,6 @@ static void dehierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   IndexVector tmpGlobalIndexVector(dfg.getDimension());
 
   IndexType gstart = dfg.getLowerBounds()[dim];
-
-  // first global index for hierarchization kernel
-  // first nonboundary point
-  IndexType idxstart = gstart;
-
-  if (gstart == 0) idxstart += 1;
-
-  // last global index inside subdomain.
-  // IndexType idxend = dfg.getUpperBounds()[dim] - 1;
-
-  // level of gend
-  // LevelType level_idxend = dfg.getLevel(dim, idxend);
   IndexType linIdxBlockStart;
 
   // loop over all xBlocks of local domain -> linearIndex with stride localndim[0]
@@ -1341,15 +1317,6 @@ void hierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
 
-  // first global index for hierarchization kernel. may not be a boundary point
-  IndexType idxstart = gstart;
-
-  if (gstart == 0) idxstart += 1;
-
-  // last global index inside subdomain and corresponding level
-  // IndexType idxend = dfg.getUpperBounds()[dim] - 1;
-  // LevelType level_idxend = dfg.getLevel(dim, idxend);
-
   for (IndexType nn = 0; nn < nbrOfPoles;
        ++nn) {  // integer operations form bottleneck here -- nested loops are twice as slow
     divresult = std::lldiv(nn, stride);
@@ -1403,15 +1370,6 @@ void hierarchizeN_opt_noboundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   lldiv_t divresult;
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
-
-  // first global index for hierarchization kernel. may not be a boundary point
-  IndexType idxstart = gstart;
-
-  if (gstart == 0) idxstart += 1;
-
-  // last global index inside subdomain and corresponding level
-  // IndexType idxend = dfg.getUpperBounds()[dim] - 1;
-  // LevelType level_idxend = dfg.getLevel(dim, idxend);
 
   for (IndexType nn = 0; nn < nbrOfPoles;
        ++nn) {  // integer operations form bottleneck here -- nested loops are twice as slow
@@ -1498,15 +1456,6 @@ void dehierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
 
-  // first global index for hierarchization kernel. may not be a boundary point
-  IndexType idxstart = gstart;
-
-  if (gstart == 0) idxstart += 1;
-
-  // last global index inside subdomain and corresponding level
-  // IndexType idxend = dfg.getUpperBounds()[dim] - 1;
-  // LevelType level_idxend = dfg.getLevel(dim, idxend);
-
   for (IndexType nn = 0; nn < nbrOfPoles;
        ++nn) {  // integer operations form bottleneck here -- nested loops are twice as slow
     divresult = std::lldiv(nn, stride);
@@ -1560,15 +1509,6 @@ void dehierarchizeN_opt_noboundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   lldiv_t divresult;
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
-
-  // first global index for hierarchization kernel. may not be a boundary point
-  IndexType idxstart = gstart;
-
-  if (gstart == 0) idxstart += 1;
-
-  // last global index inside subdomain and corresponding level
-  // IndexType idxend = dfg.getUpperBounds()[dim] - 1;
-  // LevelType level_idxend = dfg.getLevel(dim, idxend);
 
   for (IndexType nn = 0; nn < nbrOfPoles;
        ++nn) {  // integer operations form bottleneck here -- nested loops are twice as slow
@@ -1627,7 +1567,6 @@ void dehierarchizeN_opt_noboundary(DistributedFullGrid<FG_ELEMENT>& dfg,
     for (IndexType i = 0; i < ndim; ++i) ldata[start + stride * i] = tmp[gstart + i];
   }
 }
-
 
 }  // unnamed namespace
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -491,6 +491,9 @@ void sendAndReceiveIndices(std::vector<std::set<IndexType>>& send1dIndices,
 
 /**
  * @brief helper function for data exchange, have only one MPI_Isend/Irecv per rank
+ *
+ * @note for small numbers of workers per grid, this seems to be less performant. may be different
+ * for higher numbers.
  */
 template <typename FG_ELEMENT>
 void sendAndReceiveIndicesBlock(std::vector<std::set<IndexType>>& send1dIndices,

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -489,6 +489,217 @@ void sendAndReceiveIndices(std::vector<std::set<IndexType>>& send1dIndices,
   #endif */
 }
 
+/**
+ * @brief helper function for data exchange, have only one MPI_Isend/Irecv per rank
+ */
+template <typename FG_ELEMENT>
+void sendAndReceiveIndicesBlock(std::vector<std::set<IndexType>>& send1dIndices,
+                                std::vector<std::set<IndexType>>& recv1dIndices,
+                                DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
+                                std::vector<RemoteDataContainer<FG_ELEMENT>>& remoteData) {
+#ifdef DEBUG_OUTPUT
+  auto commSize = dfg.getCommunicatorSize();
+  CommunicatorType comm = dfg.getCommunicator();
+  auto rank = dfg.getRank();
+  MPI_Barrier(comm);
+
+  // print recvindices
+  {
+    for (int r = 0; r < commSize; ++r) {
+      if (r == rank) {
+        std::cout << "rank " << r << " recv1dIndices ";
+        for (const auto& r : recv1dIndices) {
+          std::cout << r;
+        }
+        std::cout << std::endl;
+      }
+      MPI_Barrier(comm);
+    }
+  }
+
+  if (rank == 0) std::cout << std::endl;
+
+  // print sendindices
+  {
+    for (int r = 0; r < commSize; ++r) {
+      if (r == rank) {
+        std::cout << "rank " << r << " send1dIndices ";
+        for (const auto& s : send1dIndices) {
+          std::cout << s;
+        }
+        std::cout << std::endl;
+      }
+      MPI_Barrier(comm);
+    }
+  }
+
+  MPI_Barrier(comm);
+
+#endif
+  // count non-empty elements of input indices
+  auto numSend = std::count_if(send1dIndices.begin(), send1dIndices.end(),
+                               [](std::set<IndexType> s) { return !s.empty(); });
+  auto numRecv = std::count_if(recv1dIndices.begin(), recv1dIndices.end(),
+                               [](std::set<IndexType> s) { return !s.empty(); });
+
+  // buffer for requests
+  std::vector<MPI_Request> sendRequests(numSend);
+  std::vector<MPI_Request> recvRequests(numRecv);
+
+  // create general subarray pointing to the first d-1 dimensional slice
+  MPI_Datatype mysubarray;
+  {
+    // sizes of local grid
+    IndexVector sizes(dfg.getLocalSizes().begin(), dfg.getLocalSizes().end());
+
+    // sizes of subarray ( full size except dimension d )
+    IndexVector subsizes = sizes;
+    subsizes[dim] = 1;
+
+    // start
+    IndexVector starts(dfg.getDimension(), 0);
+
+    // note that if we want MPI to use c ordering, for less confusion as we
+    // actually store our data in c format, we have to reverse all size and index
+    // vectors
+    std::vector<int> csizes(sizes.rbegin(), sizes.rend());
+    std::vector<int> csubsizes(subsizes.rbegin(), subsizes.rend());
+    std::vector<int> cstarts(starts.rbegin(), starts.rend());
+
+    // create subarray view on data
+    MPI_Type_create_subarray(static_cast<int>(dfg.getDimension()), &csizes[0], &csubsizes[0],
+                             &cstarts[0], MPI_ORDER_C, dfg.getMPIDatatype(), &mysubarray);
+    MPI_Type_commit(&mysubarray);
+  }
+
+  MPI_Aint dfgStartAddr;
+  MPI_Get_address(dfg.getData(), &dfgStartAddr);
+
+  // for each rank r in send1dIndices that has a nonempty index list
+  numSend = 0;
+  for (size_t r = 0; r < send1dIndices.size(); ++r) {
+    const auto& indices = send1dIndices[r];
+    if (!indices.empty()) {
+      // make datatype hblock for all indices
+      MPI_Datatype myHBlock;
+      std::vector<MPI_Aint> displacements;
+      displacements.reserve(indices.size());
+      for (const auto& index : indices) {
+        // convert global 1d index i to local 1d index
+        IndexType localLinearIndex = 0;
+        {
+          IndexVector lidxvec(dfg.getDimension(), 0);
+          IndexVector gidxvec = dfg.getLowerBounds();
+          gidxvec[dim] = index;
+          bool tmp = dfg.getLocalVectorIndex(gidxvec, lidxvec);
+          assert(tmp && "index to be send not in local domain");
+          localLinearIndex = dfg.getLocalLinearIndex(lidxvec);
+        }
+        MPI_Aint addr;
+        MPI_Get_address(&(dfg.getElementVector()[localLinearIndex]), &addr);
+        auto d = MPI_Aint_diff(addr, dfgStartAddr);
+        displacements.push_back(d);
+      }
+      assert(displacements[0] == 0);
+      // cannot use MPI_Type_create_indexed_block as subarrays may overlap
+      MPI_Type_create_hindexed_block(static_cast<int>(indices.size()), 1, displacements.data(),
+                                                   mysubarray, &myHBlock);
+      MPI_Type_commit(&myHBlock);
+
+      // send to rank r, use first global index as tag
+      {
+        int dest = static_cast<int>(r);
+        int tag = static_cast<int>(*(indices.begin()));
+        MPI_Isend(dfg.getData(), 1, myHBlock, dest, tag, dfg.getCommunicator(),
+                  &sendRequests[numSend++]);
+
+#ifdef DEBUG_OUTPUT
+        auto rank = dfg.getRank();
+        int mpiDSize = 0;
+        MPI_Type_size(myHBlock, &mpiDSize);
+        // MPI_Type_size(mysubarrayBlock, &mpiDSize);
+        // print info: dest, size, index
+        std::cout << "rank " << rank << ": send gindex " << *(indices.begin()) << " + " << displacements << " dest " << dest
+                  // << " data " << *(dfg.getData()) << " " << *(dfg.getData()+1) 
+                  // << " full data " << dfg.getElementVector()
+                  << " size " << mpiDSize
+                  << std::endl;
+
+#endif
+      }
+      // MPI_Type_free(&mysubarrayBlock);
+      MPI_Type_free(&myHBlock);
+    }
+  }
+  MPI_Type_free(&mysubarray);
+
+  // for each rank r in recv1dIndices that has a nonempty index list
+  numRecv = 0;
+  for (size_t r = 0; r < recv1dIndices.size(); ++r) {
+    const auto& indices = recv1dIndices[r];
+    if (!indices.empty()) {
+      const IndexVector& lowerBoundsNeighbor = dfg.getLowerBounds(static_cast<int>(r));
+
+      std::vector<FG_ELEMENT*> bufs;
+      IndexVector sizes = dfg.getLocalSizes();
+      sizes[dim] = 1;
+      int bsize = static_cast<int>(
+          std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<IndexType>()));
+
+      for (const auto& index : indices) {
+        // create RemoteDataContainer to store the subarray
+        remoteData.emplace_back(sizes, dim, index, lowerBoundsNeighbor);
+
+        FG_ELEMENT* buf = remoteData.back().getData();
+        bufs.push_back(buf);
+        assert(bsize == static_cast<int>(remoteData.back().getSize()));
+      }
+      {
+        // make datatype hblock for all indices
+        MPI_Datatype myHBlock;
+        MPI_Aint firstBufAddr;
+        MPI_Get_address(bufs[0], &firstBufAddr);
+        std::vector<MPI_Aint> displacements;
+        displacements.reserve(bufs.size());
+        for (const auto& b : bufs) {
+          MPI_Aint addr;
+          MPI_Get_address(b, &addr);
+          auto d = MPI_Aint_diff(addr, firstBufAddr);
+          displacements.push_back(d);
+        }
+        assert(displacements[0] == 0);
+        MPI_Type_create_hindexed_block(static_cast<int>(indices.size()), bsize, displacements.data(),
+                                       dfg.getMPIDatatype(), &myHBlock);
+        MPI_Type_commit(&myHBlock);
+        // start recv operation, use first global index as tag
+        {
+          int src = static_cast<int>(r);
+          int tag = static_cast<int>(*(indices.begin()));
+
+          MPI_Irecv(static_cast<void*>(bufs[0]), 1, myHBlock, src, tag, dfg.getCommunicator(),
+                    &recvRequests[numRecv++]);
+
+#ifdef DEBUG_OUTPUT
+          auto rank = dfg.getRank();
+          int mpiDSize = 0;
+          MPI_Type_size(myHBlock, &mpiDSize);
+          // print info: dest, size, index
+          std::cout << "rank " << rank << ": recv gindex " << *(indices.begin()) << " src " << src
+                    << " size: " << bsize << "*" << indices.size() 
+                    << " size " << mpiDSize
+                    << std::endl;
+#endif
+        }
+        MPI_Type_free(&myHBlock);
+      }
+    }
+  }
+  assert(sendRequests.size() == numSend);
+  assert(recvRequests.size() == numRecv);
+  // wait for finish of communication
+  MPI_Waitall(static_cast<int>(sendRequests.size()), &sendRequests.front(), MPI_STATUSES_IGNORE);
+  MPI_Waitall(static_cast<int>(recvRequests.size()), &recvRequests.front(), MPI_STATUSES_IGNORE);
+}
 
 // exchange data in dimension dim
 template <typename FG_ELEMENT>

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -2076,28 +2076,17 @@ namespace combigrid {
 class DistributedHierarchization {
  public:
   // inplace hierarchization
-  template <typename FG_ELEMENT,
-            void (*HIERARCHIZATION_FCTN)(FG_ELEMENT[], LevelType, int, int,
-                                         LevelType) = hierarchizeX_opt_boundary_kernel<FG_ELEMENT>>
-  static void hierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
+  template <typename FG_ELEMENT>
+  static void hierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims,const std::vector<BasisFunctionBasis*>& hierarchicalBases) {
     assert(dfg.getDimension() > 0);
     assert(dfg.getDimension() == dims.size());
-    if(HIERARCHIZATION_FCTN != &hierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
-      // mass-conserving hierarchizations make only sense w/ boundary
-      for (DimType dim = 0; dim < dfg.getDimension(); ++dim) {
-        if (dims[dim]) {
-          assert(dfg.returnBoundaryFlags()[dim]);
-        }
-      }
-    }
-
     // hierarchize all dimensions, with special treatment for 0
     for (DimType dim = 0; dim < dfg.getDimension(); ++dim) {
       if (!dims[dim]) continue;
 
       // exchange data
       std::vector<RemoteDataContainer<FG_ELEMENT>> remoteData;
-      if (HIERARCHIZATION_FCTN == &hierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
+      if (dynamic_cast<HierarchicalHatBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
         exchangeData1d(dfg, dim, remoteData);
       } else {
         exchangeAllData1d(dfg, dim, remoteData);
@@ -2105,12 +2094,59 @@ class DistributedHierarchization {
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        if (dim == 0) {
-          hierarchizeX_opt_boundary<FG_ELEMENT, HIERARCHIZATION_FCTN>(dfg, lookupTable);
+        // sorry for the code duplication, could not figure out a clean way
+        if (dynamic_cast<HierarchicalHatBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
+          if (dim == 0)
+            hierarchizeX_opt_boundary<FG_ELEMENT, hierarchizeX_opt_boundary_kernel<FG_ELEMENT>>(
+                dfg, lookupTable);
+          else
+            hierarchizeN_opt_boundary<FG_ELEMENT, hierarchizeX_opt_boundary_kernel<FG_ELEMENT>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<FullWeightingBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
+          if (dim == 0)
+            hierarchizeX_opt_boundary<
+                FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable);
+          else
+            hierarchizeN_opt_boundary<
+                FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<FullWeightingPeriodicBasisFunction*>(hierarchicalBases[dim]) !=
+                   nullptr) {
+          if (dim == 0)
+            hierarchizeX_opt_boundary<
+                FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable);
+          else
+            hierarchizeN_opt_boundary<
+                FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<BiorthogonalBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
+          if (dim == 0)
+            hierarchizeX_opt_boundary<
+                FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable);
+          else
+            hierarchizeN_opt_boundary<
+                FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<BiorthogonalPeriodicBasisFunction*>(hierarchicalBases[dim]) !=
+                   nullptr) {
+          if (dim == 0)
+            hierarchizeX_opt_boundary<
+                FG_ELEMENT, hierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable);
+          else
+            hierarchizeN_opt_boundary<
+                FG_ELEMENT, hierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable, dim);
         } else {
-          hierarchizeN_opt_boundary<FG_ELEMENT, HIERARCHIZATION_FCTN>(dfg, lookupTable, dim);
+          throw std::logic_error("Not implemented");
         }
       } else {
+        if (dynamic_cast<HierarchicalHatBasisFunction*>(hierarchicalBases[dim]) == nullptr) {
+          throw std::logic_error("currently only hats supported for non-boundary grids");
+        }
         if (dim == 0) {
           hierarchizeX_opt_noboundary(dfg, lookupTable);
         } else {
@@ -2120,17 +2156,23 @@ class DistributedHierarchization {
     }
   }
 
+  template <typename FG_ELEMENT, class T = HierarchicalHatBasisFunction>
+  static void hierarchizeHierachicalBasis(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
+    T basisFctn;
+    std::vector<BasisFunctionBasis*> bases(dfg.getDimension(), &basisFctn);
+    return hierarchize<FG_ELEMENT>(dfg, dims, bases);
+  }
+
   template <typename FG_ELEMENT>
   static void hierarchize(DistributedFullGrid<FG_ELEMENT>& dfg) {
     std::vector<bool> dims(dfg.getDimension(), true);
-    hierarchize<FG_ELEMENT>(dfg, dims);
+    return hierarchizeHierachicalBasis<FG_ELEMENT,HierarchicalHatBasisFunction>(dfg, dims);
   }
 
   // inplace dehierarchization
-  template <typename FG_ELEMENT,
-            void (*DEHIERARCHIZATION_FCTN)(FG_ELEMENT[], LevelType, int, int, LevelType) =
-                dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>>
-  static void dehierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
+  template <typename FG_ELEMENT>
+  static void dehierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims,
+                              const std::vector<BasisFunctionBasis*>& hierarchicalBases) {
     assert(dfg.getDimension() > 0);
     assert(dfg.getDimension() == dims.size());
     // dehierarchize all dimensions, with special treatment for 0
@@ -2139,7 +2181,7 @@ class DistributedHierarchization {
 
       // exchange data
       std::vector<RemoteDataContainer<FG_ELEMENT>> remoteData;
-      if (DEHIERARCHIZATION_FCTN == &dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
+      if (dynamic_cast<HierarchicalHatBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
         exchangeData1dDehierarchization(dfg, dim, remoteData);
       } else {
         exchangeAllData1d(dfg, dim, remoteData);
@@ -2147,12 +2189,59 @@ class DistributedHierarchization {
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        if (dim == 0) {
-          dehierarchizeX_opt_boundary<FG_ELEMENT, DEHIERARCHIZATION_FCTN>(dfg, lookupTable);
+        // sorry for the code duplication, could not figure out a clean way
+        if (dynamic_cast<HierarchicalHatBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
+          if (dim == 0)
+            dehierarchizeX_opt_boundary<FG_ELEMENT, dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>>(
+                dfg, lookupTable);
+          else
+            dehierarchizeN_opt_boundary<FG_ELEMENT, dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<FullWeightingBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
+          if (dim == 0)
+            dehierarchizeX_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable);
+          else
+            dehierarchizeN_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<FullWeightingPeriodicBasisFunction*>(hierarchicalBases[dim]) !=
+                   nullptr) {
+          if (dim == 0)
+            dehierarchizeX_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable);
+          else
+            dehierarchizeN_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<BiorthogonalBasisFunction*>(hierarchicalBases[dim]) != nullptr) {
+          if (dim == 0)
+            dehierarchizeX_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable);
+          else
+            dehierarchizeN_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, false>>(
+                dfg, lookupTable, dim);
+        } else if (dynamic_cast<BiorthogonalPeriodicBasisFunction*>(hierarchicalBases[dim]) !=
+                   nullptr) {
+          if (dim == 0)
+            dehierarchizeX_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable);
+          else
+            dehierarchizeN_opt_boundary<
+                FG_ELEMENT, dehierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT, true>>(
+                dfg, lookupTable, dim);
         } else {
-          dehierarchizeN_opt_boundary<FG_ELEMENT, DEHIERARCHIZATION_FCTN>(dfg, lookupTable, dim);
+          throw std::logic_error("Not implemented");
         }
       } else {
+        if (dynamic_cast<HierarchicalHatBasisFunction*>(hierarchicalBases[dim]) == nullptr) {
+          throw std::logic_error("currently only hats supported for non-boundary grids");
+        }
         if (dim == 0) {
           dehierarchizeX_opt_noboundary(dfg, lookupTable);
         } else {
@@ -2162,73 +2251,82 @@ class DistributedHierarchization {
     }
   }
 
+  template <typename FG_ELEMENT, class T = HierarchicalHatBasisFunction>
+  static void dehierarchizeHierachicalBasis(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
+    T basisFctn;
+    std::vector<BasisFunctionBasis*> bases(dfg.getDimension(), &basisFctn);
+    return dehierarchize<FG_ELEMENT>(dfg, dims, bases);
+  }
+
   template <typename FG_ELEMENT>
   static void dehierarchize(DistributedFullGrid<FG_ELEMENT>& dfg) {
     std::vector<bool> dims(dfg.getDimension(), true);
-    dehierarchize<FG_ELEMENT>(dfg, dims);
+    return dehierarchizeHierachicalBasis<FG_ELEMENT,HierarchicalHatBasisFunction>(dfg, dims);
   }
 
   template <typename FG_ELEMENT>
   static void fillDFGFromDSGU(DistributedFullGrid<FG_ELEMENT>& dfg,
-      DistributedSparseGridUniform<FG_ELEMENT>& dsg, const std::vector<bool>& hierarchizationDims){
+                              DistributedSparseGridUniform<FG_ELEMENT>& dsg,
+                              const std::vector<bool>& hierarchizationDims,
+                              const std::vector<BasisFunctionBasis*>& hierarchicalBases) {
     // fill dfg with hierarchical coefficients from distributed sparse grid
     dfg.extractFromUniformSG(dsg);
 
     // dehierarchize dfg
-    DistributedHierarchization::dehierarchize<FG_ELEMENT>(
-        dfg, hierarchizationDims);
+    DistributedHierarchization::dehierarchize<FG_ELEMENT>(dfg, hierarchizationDims,
+                                                          hierarchicalBases);
   }
 
   // make template specifications visible by alias, hat is the default
   template <typename FG_ELEMENT>
   constexpr static void (*hierarchizeHierarchicalHat)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                       const std::vector<bool>& dims) =
-      &hierarchize<FG_ELEMENT, hierarchizeX_opt_boundary_kernel<FG_ELEMENT>>;
+      &hierarchizeHierachicalBasis<FG_ELEMENT, HierarchicalHatBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*hierarchizeFullWeighting)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                     const std::vector<bool>& dims) =
-      &hierarchize<FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT>>;
+      &hierarchizeHierachicalBasis<FG_ELEMENT, FullWeightingBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*hierarchizeFullWeightingPeriodic)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                     const std::vector<bool>& dims) =
-      &hierarchize<FG_ELEMENT, hierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, true>>;
+      &hierarchizeHierachicalBasis<FG_ELEMENT, FullWeightingPeriodicBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*hierarchizeBiorthogonal)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                    const std::vector<bool>& dims) =
-      &hierarchize<FG_ELEMENT, hierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT>>;
+      &hierarchizeHierachicalBasis<FG_ELEMENT, BiorthogonalBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*hierarchizeBiorthogonalPeriodic)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                    const std::vector<bool>& dims) =
-      &hierarchize<FG_ELEMENT, hierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT, true>>;
+      &hierarchizeHierachicalBasis<FG_ELEMENT, BiorthogonalPeriodicBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*dehierarchizeHierarchicalHat)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                         const std::vector<bool>& dims) =
-      &dehierarchize<FG_ELEMENT, dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>>;
+      &dehierarchizeHierachicalBasis<FG_ELEMENT, HierarchicalHatBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*dehierarchizeFullWeighting)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                       const std::vector<bool>& dims) =
-      &dehierarchize<FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT>>;
+      &dehierarchizeHierachicalBasis<FG_ELEMENT, FullWeightingBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*dehierarchizeFullWeightingPeriodic)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                       const std::vector<bool>& dims) =
-      &dehierarchize<FG_ELEMENT, dehierarchizeX_full_weighting_boundary_kernel<FG_ELEMENT, true>>;
+      &dehierarchizeHierachicalBasis<FG_ELEMENT, FullWeightingPeriodicBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*dehierarchizeBiorthogonal)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                      const std::vector<bool>& dims) =
-      &dehierarchize<FG_ELEMENT, dehierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT>>;
+      &dehierarchizeHierachicalBasis<FG_ELEMENT, BiorthogonalBasisFunction>;
 
   template <typename FG_ELEMENT>
   constexpr static void (*dehierarchizeBiorthogonalPeriodic)(DistributedFullGrid<FG_ELEMENT>& dfg,
                                                      const std::vector<bool>& dims) =
-      &dehierarchize<FG_ELEMENT, dehierarchizeX_biorthogonal_boundary_kernel<FG_ELEMENT, true>>;
+      &dehierarchizeHierachicalBasis<FG_ELEMENT, BiorthogonalPeriodicBasisFunction>;
 
 };
 // class DistributedHierarchization

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -2091,33 +2091,13 @@ class DistributedHierarchization {
       }
     }
 
-    // hierarchize first dimension
-    if (dims[0]) {
-      DimType dim = 0;
-
-      // exchange data first dimension
-      std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      if(HIERARCHIZATION_FCTN == &hierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
-        exchangeData1d<FG_ELEMENT>(dfg, dim, remoteData);
-      } else {
-        exchangeAllData1d(dfg, dim, remoteData);
-      }
-      LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
-
-      if (dfg.returnBoundaryFlags()[dim] == true) {
-        hierarchizeX_opt_boundary<FG_ELEMENT, HIERARCHIZATION_FCTN>(dfg, lookupTable);
-      } else {
-        hierarchizeX_opt_noboundary(dfg, lookupTable);
-      }
-    }
-
-    // hierarchize other dimensions
-    for (DimType dim = 1; dim < dfg.getDimension(); ++dim) {
+    // hierarchize all dimensions, with special treatment for 0
+    for (DimType dim = 0; dim < dfg.getDimension(); ++dim) {
       if (!dims[dim]) continue;
 
       // exchange data
-      std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      if(HIERARCHIZATION_FCTN == &hierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
+      std::vector<RemoteDataContainer<FG_ELEMENT>> remoteData;
+      if (HIERARCHIZATION_FCTN == &hierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
         exchangeData1d(dfg, dim, remoteData);
       } else {
         exchangeAllData1d(dfg, dim, remoteData);
@@ -2125,9 +2105,17 @@ class DistributedHierarchization {
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        hierarchizeN_opt_boundary<FG_ELEMENT, HIERARCHIZATION_FCTN>(dfg, lookupTable, dim);
+        if (dim == 0) {
+          hierarchizeX_opt_boundary<FG_ELEMENT, HIERARCHIZATION_FCTN>(dfg, lookupTable);
+        } else {
+          hierarchizeN_opt_boundary<FG_ELEMENT, HIERARCHIZATION_FCTN>(dfg, lookupTable, dim);
+        }
       } else {
-        hierarchizeN_opt_noboundary(dfg, lookupTable, dim);
+        if (dim == 0) {
+          hierarchizeX_opt_noboundary(dfg, lookupTable);
+        } else {
+          hierarchizeN_opt_noboundary(dfg, lookupTable, dim);
+        }
       }
     }
   }
@@ -2140,39 +2128,18 @@ class DistributedHierarchization {
 
   // inplace dehierarchization
   template <typename FG_ELEMENT,
-            void (*DEHIERARCHIZATION_FCTN)(FG_ELEMENT[], LevelType, int, int,
-                                         LevelType) = dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>>
+            void (*DEHIERARCHIZATION_FCTN)(FG_ELEMENT[], LevelType, int, int, LevelType) =
+                dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>>
   static void dehierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
     assert(dfg.getDimension() > 0);
     assert(dfg.getDimension() == dims.size());
-
-    // dehierarchize first dimension
-    if (dims[0]) {
-      DimType dim = 0;
-
-      // exchange data first dimension
-      std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      if(DEHIERARCHIZATION_FCTN == &dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
-        exchangeData1dDehierarchization(dfg, dim, remoteData);
-      } else {
-        exchangeAllData1d(dfg, dim, remoteData);
-      }
-      LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
-
-      if (dfg.returnBoundaryFlags()[dim] == true) {
-        dehierarchizeX_opt_boundary<FG_ELEMENT, DEHIERARCHIZATION_FCTN>(dfg, lookupTable);
-      } else {
-        dehierarchizeX_opt_noboundary(dfg, lookupTable);
-      }
-    }
-
-    // dehierarchize other dimensions
-    for (DimType dim = 1; dim < dfg.getDimension(); ++dim) {
+    // dehierarchize all dimensions, with special treatment for 0
+    for (DimType dim = 0; dim < dfg.getDimension(); ++dim) {
       if (!dims[dim]) continue;
 
       // exchange data
-      std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      if(DEHIERARCHIZATION_FCTN == &dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
+      std::vector<RemoteDataContainer<FG_ELEMENT>> remoteData;
+      if (DEHIERARCHIZATION_FCTN == &dehierarchizeX_opt_boundary_kernel<FG_ELEMENT>) {
         exchangeData1dDehierarchization(dfg, dim, remoteData);
       } else {
         exchangeAllData1d(dfg, dim, remoteData);
@@ -2180,9 +2147,17 @@ class DistributedHierarchization {
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        dehierarchizeN_opt_boundary<FG_ELEMENT, DEHIERARCHIZATION_FCTN>(dfg, lookupTable, dim);
+        if (dim == 0) {
+          dehierarchizeX_opt_boundary<FG_ELEMENT, DEHIERARCHIZATION_FCTN>(dfg, lookupTable);
+        } else {
+          dehierarchizeN_opt_boundary<FG_ELEMENT, DEHIERARCHIZATION_FCTN>(dfg, lookupTable, dim);
+        }
       } else {
-        dehierarchizeN_opt_noboundary(dfg, lookupTable, dim);
+        if (dim == 0) {
+          dehierarchizeX_opt_noboundary(dfg, lookupTable);
+        } else {
+          dehierarchizeN_opt_noboundary(dfg, lookupTable, dim);
+        }
       }
     }
   }

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -299,6 +299,15 @@ template <typename FG_ELEMENT>
 void dehierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
                                  LookupTable<FG_ELEMENT>& lookupTable, DimType dim);
 
+void storeAllUniqueAscending(std::vector<IndexVector>& indicesOnOtherRanks) {
+  // store only unique indices and sort ascending
+  for (auto& indicesOnRank : indicesOnOtherRanks) {
+    std::sort(indicesOnRank.begin(), indicesOnRank.end());
+    IndexVector::iterator it = std::unique(indicesOnRank.begin(), indicesOnRank.end());
+    indicesOnRank.resize(std::distance(indicesOnRank.begin(), it));
+  }
+}
+
 // exchange data in dimension dim
 template <typename FG_ELEMENT>
 static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
@@ -443,21 +452,8 @@ static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
   }
 
   // store only unique indices and sort ascending
-  for (RankType k = 0; k < dfg.getCommunicatorSize(); ++k) {
-    if (recv1dIndices[k].size() > 0) {
-      IndexVector& tmp = recv1dIndices[k];
-      std::sort(tmp.begin(), tmp.end());
-      IndexVector::iterator it = std::unique(tmp.begin(), tmp.end());
-      tmp.resize(std::distance(tmp.begin(), it));
-    }
-
-    if (send1dIndices[k].size() > 0) {
-      IndexVector& tmp = send1dIndices[k];
-      std::sort(tmp.begin(), tmp.end());
-      IndexVector::iterator it = std::unique(tmp.begin(), tmp.end());
-      tmp.resize(std::distance(tmp.begin(), it));
-    }
-  }
+  storeAllUniqueAscending(recv1dIndices);
+  storeAllUniqueAscending(send1dIndices);
 
 #ifdef DEBUG_OUTPUT
   // print recvindices
@@ -779,21 +775,8 @@ static void exchangeData1dDehierarchization(
   }
 
   // store only unique indices and sort ascending
-  for (RankType k = 0; k < dfg.getCommunicatorSize(); ++k) {
-    if (recv1dIndices[k].size() > 0) {
-      IndexVector& tmp = recv1dIndices[k];
-      std::sort(tmp.begin(), tmp.end());
-      IndexVector::iterator it = std::unique(tmp.begin(), tmp.end());
-      tmp.resize(std::distance(tmp.begin(), it));
-    }
-
-    if (send1dIndices[k].size() > 0) {
-      IndexVector& tmp = send1dIndices[k];
-      std::sort(tmp.begin(), tmp.end());
-      IndexVector::iterator it = std::unique(tmp.begin(), tmp.end());
-      tmp.resize(std::distance(tmp.begin(), it));
-    }
-  }
+  storeAllUniqueAscending(recv1dIndices);
+  storeAllUniqueAscending(send1dIndices);
 
 #ifdef DEBUG_OUTPUT
   MPI_Barrier(comm);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/hierarchization/DistributedHierarchization.hpp
@@ -250,16 +250,17 @@ static void exchangeData1dDehierarchization(
 template <typename FG_ELEMENT>
 static void checkLeftSuccesors(IndexType checkIdx, IndexType rootIdx, DimType dim,
                                DistributedFullGrid<FG_ELEMENT>& dfg,
-                               std::vector<std::set<IndexType>>& OneDIndices);
+                               std::vector<std::set<IndexType>>& OneDIndices, LevelType lmin);
 
 template <typename FG_ELEMENT>
 static void checkRightSuccesors(IndexType checkIdx, IndexType rootIdx, DimType dim,
                                 DistributedFullGrid<FG_ELEMENT>& dfg,
-                                std::vector<std::set<IndexType>>& OneDIndices);
+                                std::vector<std::set<IndexType>>& OneDIndices, LevelType lmin);
 
 template <typename FG_ELEMENT>
 static IndexType checkPredecessors(IndexType idx, DimType dim, DistributedFullGrid<FG_ELEMENT>& dfg,
-                                   std::vector<std::set<IndexType>>& OneDIndices, bool andNeighbors = false);
+                                   std::vector<std::set<IndexType>>& OneDIndices, LevelType lmin,
+                                   bool andNeighbors = false);
 
 template <typename FG_ELEMENT>
 static RankType getNeighbor1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType d, IndexType idx1d);
@@ -524,8 +525,8 @@ void sendAndReceiveIndices(std::vector<std::set<IndexType>>& send1dIndices,
 // exchange data in dimension dim
 template <typename FG_ELEMENT>
 static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
-                           std::vector<RemoteDataContainer<FG_ELEMENT> >& remoteData) {
-
+                           std::vector<RemoteDataContainer<FG_ELEMENT>>& remoteData,
+                           LevelType lmin = 0) {
   auto commSize = dfg.getCommunicatorSize();
 #ifdef DEBUG_OUTPUT
   CommunicatorType comm = dfg.getCommunicator();
@@ -609,38 +610,47 @@ static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
     // check if successors of idx outside local domain
     {
       for (LevelType l = lidx + 1; l <= lmax; ++l) {
-        LevelType ldiff = lmax - l;
-        IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
+        // only send if successors on level l need to be hierarchized
+        if (l > lmin) {
+          LevelType ldiff = lmax - l;
+          IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
 
-        // left successor, right successor
-        for (const auto& indexShift : {-1, 1}) {
-          IndexType sIdx = idx + indexShift * idiff;
-          // if sIdx is outside of my domain, but still in the global domain
-          if ((indexShift < 0 && sIdx >= 0 && sIdx < idxMin) ||
-              (indexShift > 0 && sIdx > idxMax && sIdx < globalIdxMax)) {
-            // get rank which has sIdx and add to send list
-            int r = getNeighbor1d(dfg, dim, sIdx);
-            if (r >= 0) send1dIndices[r].insert(idx);
+          // left successor, right successor
+          for (const auto& indexShift : {-1, 1}) {
+            IndexType sIdx = idx + indexShift * idiff;
+            // if sIdx is outside of my domain, but still in the global domain
+            if ((indexShift < 0 && sIdx >= 0 && sIdx < idxMin) ||
+                (indexShift > 0 && sIdx > idxMax && sIdx < globalIdxMax)) {
+              // get rank which has sIdx and add to send list
+              int r = getNeighbor1d(dfg, dim, sIdx);
+              if (r >= 0) send1dIndices[r].insert(idx);
+            }
           }
         }
       }
     }
     LevelType ldiff = lmax - lidx;
     IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
-    // check if predecessors of idx outside local domain
     IndexType pIdx;
-    // left, right predecessor
-    for (const auto& indexShift : {-1, 1}) {
-      pIdx = idx + indexShift * idiff;
-      // if we are not on the boundary level, and
-      // pIdx is outside of my domain, but still in the global domain
-      if (lidx > 0 && ((indexShift < 0 && pIdx >= 0 && pIdx < idxMin) ||
-                        (indexShift > 0 && pIdx > idxMax && pIdx < globalIdxMax))) {
-        // get rank which has predecessor and add to list of indices to recv
-        int r = getNeighbor1d(dfg, dim, pIdx);
-        recv1dIndices[r].insert(pIdx);
+    // only recv if this index idx needs to be hierarchized
+    if (lidx > lmin) {
+      // check if predecessors of idx outside local domain
+      // left, right predecessor
+      for (const auto& indexShift : {-1, 1}) {
+        pIdx = idx + indexShift * idiff;
+        // if we are not on the boundary level, and
+        // pIdx is outside of my domain, but still in the global domain
+        if (lidx > 0 && ((indexShift < 0 && pIdx >= 0 && pIdx < idxMin) ||
+                         (indexShift > 0 && pIdx > idxMax && pIdx < globalIdxMax))) {
+          // get rank which has predecessor and add to list of indices to recv
+          int r = getNeighbor1d(dfg, dim, pIdx);
+          recv1dIndices[r].insert(pIdx);
+        }
       }
+    } else {
+      pIdx = idx + idiff;
     }
+
     if (lidx == 0 || pIdx > idxMax) {
       idx = getNextIndex1d(dfg, dim, idx);
     } else {
@@ -688,13 +698,11 @@ static void exchangeData1d(DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
   sendAndReceiveIndices(send1dIndices, recv1dIndices, dfg, dim, remoteData);
 }
 
-
 // exchange data in dimension dim
 template <typename FG_ELEMENT>
 static void exchangeData1dDehierarchization(
     DistributedFullGrid<FG_ELEMENT>& dfg, DimType dim,
-    std::vector<RemoteDataContainer<FG_ELEMENT> >& remoteData) {
-
+    std::vector<RemoteDataContainer<FG_ELEMENT>>& remoteData, LevelType lmin = 0) {
   auto commSize = dfg.getCommunicatorSize();
 #ifdef DEBUG_OUTPUT
   CommunicatorType comm = dfg.getCommunicator();
@@ -772,9 +780,10 @@ static void exchangeData1dDehierarchization(
   // for dehierarchization, we need to exchange the full tree of
   // successors and predecessors
   while (idx <= idxMax) {
-    checkLeftSuccesors(idx, idx, dim, dfg, send1dIndices);
 
-    checkRightSuccesors(idx, idx, dim, dfg, send1dIndices);
+    LevelType lidx = dfg.getLevel(dim, idx);
+    checkLeftSuccesors(idx, idx, dim, dfg, send1dIndices, lmin);
+    checkRightSuccesors(idx, idx, dim, dfg, send1dIndices, lmin);
 
     // if we have an odd 5-point stencil, each point also
     // needs to check for its same level neighbors
@@ -786,8 +795,8 @@ static void exchangeData1dDehierarchization(
       IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff + 1));
       // left neighbor
       IndexType nIdx = idx - idiff;
-      checkLeftSuccesors(nIdx, idx, dim, dfg, send1dIndices);
-      checkRightSuccesors(nIdx, idx, dim, dfg, send1dIndices);
+      checkLeftSuccesors(nIdx, idx, dim, dfg, send1dIndices, lmin);
+      checkRightSuccesors(nIdx, idx, dim, dfg, send1dIndices, lmin);
       // if nIdx is in the global domain
       if (nIdx > -1 && nIdx < idxMin) {
         int r = getNeighbor1d(dfg, dim, nIdx);
@@ -795,8 +804,8 @@ static void exchangeData1dDehierarchization(
       }
       // right neighbor
       nIdx = idx + idiff;
-      checkLeftSuccesors(nIdx, idx, dim, dfg, send1dIndices);
-      checkRightSuccesors(nIdx, idx, dim, dfg, send1dIndices);
+      checkLeftSuccesors(nIdx, idx, dim, dfg, send1dIndices, lmin);
+      checkRightSuccesors(nIdx, idx, dim, dfg, send1dIndices, lmin);
       if (nIdx > idxMax && nIdx < dfg.getGlobalSizes()[dim]) {
         int r = getNeighbor1d(dfg, dim, nIdx);
         send1dIndices[r].insert(idx);
@@ -805,7 +814,7 @@ static void exchangeData1dDehierarchization(
       assert(false);
     }
 
-    idx = checkPredecessors(idx, dim, dfg, recv1dIndices, exchangeParentsNeighbors);
+    idx = checkPredecessors(idx, dim, dfg, recv1dIndices, lmin, exchangeParentsNeighbors);
   }
 
   sendAndReceiveIndices(send1dIndices, recv1dIndices, dfg, dim, remoteData);
@@ -814,7 +823,7 @@ static void exchangeData1dDehierarchization(
 template <typename FG_ELEMENT>
 static void checkLeftSuccesors(IndexType checkIdx, IndexType rootIdx, DimType dim,
                                DistributedFullGrid<FG_ELEMENT>& dfg,
-                               std::vector<std::set<IndexType>>& OneDIndices) {
+                               std::vector<std::set<IndexType>>& OneDIndices, LevelType lmin) {
   LevelType lidx = dfg.getLevel(dim, checkIdx);
   IndexType idxMin = dfg.getFirstGlobal1dIndex(dim);
   // IndexType idxMax = dfg.getLastGlobal1dIndex(dim);
@@ -822,25 +831,29 @@ static void checkLeftSuccesors(IndexType checkIdx, IndexType rootIdx, DimType di
 
   // check left successors of checkIdx
   for (LevelType l = lidx + 1; l <= lmax; ++l) {
-    LevelType ldiff = lmax - l;
-    IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
 
-    IndexType lsIdx = checkIdx - idiff;
+    // only send if my successors on level l need to be dehierarchized
+    if (l > lmin) {
+      LevelType ldiff = lmax - l;
+      IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
 
-    if (lsIdx >= 0 && lsIdx < idxMin) {
-      // get rank which has lsIdx and add to send list
-      int r = getNeighbor1d(dfg, dim, lsIdx);
-      if (r >= 0) OneDIndices[r].insert(rootIdx);
+      IndexType lsIdx = checkIdx - idiff;
+
+      if (lsIdx >= 0 && lsIdx < idxMin) {
+        // get rank which has lsIdx and add to send list
+        int r = getNeighbor1d(dfg, dim, lsIdx);
+        if (r >= 0) OneDIndices[r].insert(rootIdx);
+      }
+
+      if (lsIdx >= 0) checkLeftSuccesors(lsIdx, rootIdx, dim, dfg, OneDIndices, lmin);
     }
-
-    if (lsIdx >= 0) checkLeftSuccesors(lsIdx, rootIdx, dim, dfg, OneDIndices);
   }
 }
 
 template <typename FG_ELEMENT>
-static void checkRightSuccesors(IndexType checkIdx, IndexType rootIdx, DimType dim,
-                                DistributedFullGrid<FG_ELEMENT>& dfg,
-                                std::vector<std::set<IndexType>>& OneDIndices) {
+static void checkRightSuccesors(
+    IndexType checkIdx, IndexType rootIdx, DimType dim, DistributedFullGrid<FG_ELEMENT> & dfg,
+    std::vector<std::set<IndexType>> & OneDIndices, LevelType lmin) {
   LevelType lidx = dfg.getLevel(dim, checkIdx);
 
   IndexType idxMax = dfg.getLastGlobal1dIndex(dim);
@@ -848,106 +861,113 @@ static void checkRightSuccesors(IndexType checkIdx, IndexType rootIdx, DimType d
 
   // check right successors of checkIdx
   for (LevelType l = lidx + 1; l <= lmax; ++l) {
-    LevelType ldiff = lmax - l;
-    IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
+    // only send if my successors on level l need to be dehierarchized
+    if (l > lmin) {
+      LevelType ldiff = lmax - l;
+      IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff));
 
-    IndexType rsIdx = checkIdx + idiff;
+      IndexType rsIdx = checkIdx + idiff;
 
-    if (rsIdx < dfg.getGlobalSizes()[dim] && rsIdx > idxMax) {
-      // get rank which has rsIdx and add to send list
-      int r = getNeighbor1d(dfg, dim, rsIdx);
-      if (r >= 0) OneDIndices[r].insert(rootIdx);
-    }
+      if (rsIdx < dfg.getGlobalSizes()[dim] && rsIdx > idxMax) {
+        // get rank which has rsIdx and add to send list
+        int r = getNeighbor1d(dfg, dim, rsIdx);
+        if (r >= 0) OneDIndices[r].insert(rootIdx);
+      }
 
-    if (rsIdx < dfg.length(dim)) {
-      checkRightSuccesors(rsIdx, rootIdx, dim, dfg, OneDIndices);
+      if (rsIdx < dfg.length(dim)) {
+        checkRightSuccesors(rsIdx, rootIdx, dim, dfg, OneDIndices, lmin);
+      }
     }
   }
 }
 
 template <typename FG_ELEMENT>
 static IndexType checkPredecessors(IndexType idx, DimType dim, DistributedFullGrid<FG_ELEMENT>& dfg,
-                                   std::vector<std::set<IndexType>>& OneDIndices,
+                                   std::vector<std::set<IndexType>>& OneDIndices, LevelType lmin,
                                    bool andNeighbors) {
-  IndexType idxMin = dfg.getFirstGlobal1dIndex(dim);
-  IndexType idxMax = dfg.getLastGlobal1dIndex(dim);
-
-  auto lmax = dfg.getLevels()[dim];
   auto lidx = dfg.getLevel(dim, idx);
-  if (andNeighbors) {
-    // add same-level neighbors
-    LevelType ldiff = lmax - lidx;
-    IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff + 1));
-    // left neighbor
-    IndexType nIdx = idx - idiff;
-    // if nIdx is in the global domain
-    if (nIdx > -1 && nIdx < idxMin) {
-      // get rank which has same-level neighbor and add to list of indices to recv
-      int r = getNeighbor1d(dfg, dim, nIdx);
-      OneDIndices[r].insert(nIdx);
+  // if this level is lmin or smaller, idx does not need to be dehierarchized
+  // and we can end recursing here
+  if (lidx > lmin) {
+    IndexType idxMin = dfg.getFirstGlobal1dIndex(dim);
+    IndexType idxMax = dfg.getLastGlobal1dIndex(dim);
+    auto lmax = dfg.getLevels()[dim];
+    if (andNeighbors) {
+      // add same-level neighbors
+      LevelType ldiff = lmax - lidx;
+      IndexType idiff = static_cast<IndexType>(std::pow(2, ldiff + 1));
+      // left neighbor
+      IndexType nIdx = idx - idiff;
+      // if nIdx is in the global domain
+      if (nIdx > -1 && nIdx < idxMin) {
+        // get rank which has same-level neighbor and add to list of indices to recv
+        int r = getNeighbor1d(dfg, dim, nIdx);
+        OneDIndices[r].insert(nIdx);
+      }
+      // right neighbor
+      nIdx = idx + idiff;
+      if (nIdx > idxMax && nIdx < dfg.getGlobalSizes()[dim]) {
+        int r = getNeighbor1d(dfg, dim, nIdx);
+        OneDIndices[r].insert(nIdx);
+      }
     }
-    // right neighbor
-    nIdx = idx + idiff;
-    if (nIdx > idxMax && nIdx < dfg.getGlobalSizes()[dim]) {
-      int r = getNeighbor1d(dfg, dim, nIdx);
-      OneDIndices[r].insert(nIdx);
+
+    // check if left predecessor outside local domain
+    // if returns negative value there's no left predecessor
+    IndexType lpIdx = dfg.getLeftPredecessor(dim, idx);
+
+    if (lpIdx >= 0 && lpIdx < idxMin) {
+      // get rank which has left predecessor and add to list of indices
+      int r = getNeighbor1d(dfg, dim, lpIdx);
+      OneDIndices[r].insert(lpIdx);
     }
-  }
+    if (lpIdx >= 0) checkPredecessors(lpIdx, dim, dfg, OneDIndices, lmin, andNeighbors);
 
-  // check if left predecessor outside local domain
-  // if returns negative value there's no left predecessor
-  IndexType lpIdx = dfg.getLeftPredecessor(dim, idx);
+    // check if right predecessor outside local domain
+    // if returns negative value there's no right predecessor
+    IndexType rpIdx = dfg.getRightPredecessor(dim, idx);
 
-  if (lpIdx >= 0 && lpIdx < idxMin) {
-    // get rank which has left predecessor and add to list of indices
-    int r = getNeighbor1d(dfg, dim, lpIdx);
-    OneDIndices[r].insert(lpIdx);
-  }
-  if (lpIdx >= 0) checkPredecessors(lpIdx, dim, dfg, OneDIndices, andNeighbors);
+    if (rpIdx < 0) {
+      idx = getNextIndex1d(dfg, dim, idx);
+      return idx;
+    }
 
-  // check if right predecessor outside local domain
-  // if returns negative value there's no right predecessor
-  IndexType rpIdx = dfg.getRightPredecessor(dim, idx);
+    if (rpIdx > idxMax) {
+      // get rank which has right predecessor and add to list of indices to recv
+      int r = getNeighbor1d(dfg, dim, rpIdx);
+      OneDIndices[r].insert(rpIdx);
+      idx = getNextIndex1d(dfg, dim, idx);
+    } else if (andNeighbors) {
+      // if not all leftmost indices have been iterated
+      auto firstIndices = getFirstIndexOfEachLevel1d(dfg, dim);
+  #ifdef DEBUG_OUTPUT
+          auto rank = dfg.getRank();
+          std::cout << "rank " << rank << ": first indices " << firstIndices
+                    << std::endl;
+  #endif
+      std::sort(firstIndices.begin(), firstIndices.end()); //todo also last indices
+      assert(false);
+      auto it = std::find_if(firstIndices.begin(), firstIndices.end(),
+                            [idx](IndexType i) { return i > idx; });
+      if (it != firstIndices.end() && rpIdx > *it) {
+        idx = *it;
+      } else {
+        idx = rpIdx;
+      }
 
-  if (rpIdx < 0) {
-    idx = getNextIndex1d(dfg, dim, idx);
-    return idx;
-  }
-
-  if (rpIdx > idxMax) {
-    // get rank which has right predecessor and add to list of indices to recv
-    int r = getNeighbor1d(dfg, dim, rpIdx);
-    OneDIndices[r].insert(rpIdx);
-    idx = getNextIndex1d(dfg, dim, idx);
-  } else if (andNeighbors) {
-    // if not all leftmost indices have been iterated
-    auto firstIndices = getFirstIndexOfEachLevel1d(dfg, dim);
-#ifdef DEBUG_OUTPUT
-        auto rank = dfg.getRank();
-        std::cout << "rank " << rank << ": first indices " << firstIndices
-                  << std::endl;
-#endif
-    std::sort(firstIndices.begin(), firstIndices.end()); //todo also last indices
-    assert(false);
-    auto it = std::find_if(firstIndices.begin(), firstIndices.end(),
-                           [idx](IndexType i) { return i > idx; });
-    if (it != firstIndices.end() && rpIdx > *it) {
-      idx = *it;
+  #ifdef DEBUG_OUTPUT
+          // auto rank = dfg.getRank();
+          std::cout << "rank " << rank << ": first indices " << firstIndices << " it " << *it
+                    << std::endl;
+  #endif
     } else {
       idx = rpIdx;
     }
 
-#ifdef DEBUG_OUTPUT
-        // auto rank = dfg.getRank();
-        std::cout << "rank " << rank << ": first indices " << firstIndices << " it " << *it
-                  << std::endl;
-#endif
+    checkPredecessors(rpIdx, dim, dfg, OneDIndices, lmin, andNeighbors);
   } else {
-    idx = rpIdx;
+      idx = getNextIndex1d(dfg, dim, idx);
   }
-
-  checkPredecessors(rpIdx, dim, dfg, OneDIndices, andNeighbors);
-
   return idx;
 }
 
@@ -1199,7 +1219,7 @@ static void dehierarchizeX_opt_noboundary(DistributedFullGrid<FG_ELEMENT>& dfg,
 
 template <typename FG_ELEMENT>
 inline void hierarchizeX_opt_boundary_kernel(FG_ELEMENT* data, LevelType lmax, int start,
-                                             int stride) {
+                                             int stride, LevelType lmin = 0) {
   const int lmaxi = static_cast<int>(lmax);
   int ll = lmaxi;
   int steps = (1 << (lmaxi - 1));
@@ -1207,7 +1227,7 @@ inline void hierarchizeX_opt_boundary_kernel(FG_ELEMENT* data, LevelType lmax, i
   int stepsize = 2;
   int parentOffset = 1;
 
-  for (ll--; ll > -1; ll--) {
+  for (ll--; ll > lmin - 1; ll--) {
     int parOffsetStrided = parentOffset * stride;
     FG_ELEMENT parentL = 0.5 * data[start + offset * stride - parOffsetStrided];
 
@@ -1322,14 +1342,15 @@ inline void hierarchizeX_biorthogonal_boundary_kernel(FG_ELEMENT* data, LevelTyp
 
 template <typename FG_ELEMENT>
 inline void dehierarchizeX_opt_boundary_kernel(FG_ELEMENT* data, LevelType lmax, int start,
-                                               int stride) {
+                                               int stride, LevelType lmin = 0) {
   const int lmaxi = static_cast<int>(lmax);
-  int steps = 1;
-  int offset = (1 << (lmaxi - 1));  // offset =1 da boundary.
-  int stepsize = (1 << lmaxi);
-  int parentOffset = (1 << (lmaxi - 1));
+  const int lmini = static_cast<int>(lmin);
+  int steps = 1 << (lmini);
+  int offset = (1 << (lmaxi - lmini - 1));
+  int stepsize = (1 << (lmaxi - lmini));
+  int parentOffset = offset;
 
-  for (LevelType ll = 1; ll <= lmax; ++ll) {
+  for (LevelType ll = lmin + 1; ll <= lmax; ++ll) {
     int parOffsetStrided = parentOffset * stride;
     FG_ELEMENT parentL = 0.5 * data[start + offset * stride - parOffsetStrided];
 
@@ -1421,7 +1442,7 @@ inline void dehierarchizeX_biorthogonal_boundary_kernel(FG_ELEMENT* data, LevelT
  */
 template <typename FG_ELEMENT>
 static void hierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                      LookupTable<FG_ELEMENT>& lookupTable) {
+                                      LookupTable<FG_ELEMENT>& lookupTable, LevelType lmin_x = 0) {
   const DimType dim = 0;
   assert(dfg.returnBoundaryFlags()[dim] == true);
 
@@ -1468,6 +1489,10 @@ static void hierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
       tmp[global1didx] = *rdcs[i].getData(tmpGlobalIndexVector);
     }
 
+    hierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_x);
+    // hierarchizeX_full_weighting_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_x);
+    // hierarchizeX_biorthogonal_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_x);
+
     hierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1);
 
     // copy local data back
@@ -1477,7 +1502,8 @@ static void hierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
 
 template <typename FG_ELEMENT>
 static void dehierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                        LookupTable<FG_ELEMENT>& lookupTable) {
+                                        LookupTable<FG_ELEMENT>& lookupTable,
+                                        LevelType lmin_x = 0) {
   const DimType dim = 0;
   assert(dfg.returnBoundaryFlags()[dim] == true);
 
@@ -1525,6 +1551,9 @@ static void dehierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
     }
 
     dehierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1);
+    dehierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_x);
+    // dehierarchizeX_full_weighting_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_x);
+    // dehierarchizeX_biorthogonal_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_x);
 
     // copy local data back
     for (IndexType i = 0; i < xSize; ++i) localData[linIdxBlockStart + i] = tmp[gstart + i];
@@ -1533,7 +1562,8 @@ static void dehierarchizeX_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
 
 template <typename FG_ELEMENT>
 void hierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                               LookupTable<FG_ELEMENT>& lookupTable, DimType dim) {
+                               LookupTable<FG_ELEMENT>& lookupTable, DimType dim,
+                               LevelType lmin_n = 0) {
   assert(dfg.returnBoundaryFlags()[dim] == true);
 
   LevelType lmax = dfg.getLevels()[dim];
@@ -1578,7 +1608,9 @@ void hierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
     for (IndexType i = 0; i < ndim; ++i) tmp[gstart + i] = ldata[start + stride * i];
 
     // hierarchize tmp array with hupp function
-    hierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1);
+    hierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_n);
+    // hierarchizeX_full_weighting_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_n);
+    // hierarchizeX_biorthogonal_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_n);
 
     // copy pole back
     for (IndexType i = 0; i < ndim; ++i) ldata[start + stride * i] = tmp[gstart + i];
@@ -1672,7 +1704,8 @@ void hierarchizeN_opt_noboundary(DistributedFullGrid<FG_ELEMENT>& dfg,
 
 template <typename FG_ELEMENT>
 void dehierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
-                                 LookupTable<FG_ELEMENT>& lookupTable, DimType dim) {
+                                 LookupTable<FG_ELEMENT>& lookupTable, DimType dim,
+                                 LevelType lmin_n = 0) {
   assert(dfg.returnBoundaryFlags()[dim] == true);
 
   LevelType lmax = dfg.getLevels()[dim];
@@ -1717,7 +1750,9 @@ void dehierarchizeN_opt_boundary(DistributedFullGrid<FG_ELEMENT>& dfg,
     for (IndexType i = 0; i < ndim; ++i) tmp[gstart + i] = ldata[start + stride * i];
 
     // hierarchize tmp array with hupp function
-    dehierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1);
+    dehierarchizeX_opt_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_n);
+    // dehierarchizeX_full_weighting_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_n);
+    // dehierarchizeX_biorthogonal_boundary_kernel(&tmp[0], lmax, 0, 1, lmin_n);
 
     // copy pole back
     for (IndexType i = 0; i < ndim; ++i) ldata[start + stride * i] = tmp[gstart + i];
@@ -1814,9 +1849,13 @@ class DistributedHierarchization {
  public:
   // inplace hierarchization
   template <typename FG_ELEMENT>
-  static void hierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
+  static void hierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims,
+                          LevelVector lmin = LevelVector(0)) {
     assert(dfg.getDimension() > 0);
     assert(dfg.getDimension() == dims.size());
+    if (lmin.size() == 0) {
+      lmin = LevelVector(dims.size(), 0);
+    }
 
     // hierarchize first dimension
     if (dims[0]) {
@@ -1824,14 +1863,15 @@ class DistributedHierarchization {
 
       // exchange data first dimension
       std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      exchangeData1d(dfg, dim, remoteData);
+      exchangeData1d(dfg, dim, remoteData, lmin[dim]);
 
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        hierarchizeX_opt_boundary(dfg, lookupTable);
+        hierarchizeX_opt_boundary(dfg, lookupTable, lmin[dim]);
       } else {
-        hierarchizeX_opt_noboundary(dfg, lookupTable);
+        assert(lmin == 0);
+        hierarchizeX_opt_noboundary(dfg, lookupTable); //TODO lmin
       }
     }
 
@@ -1841,12 +1881,13 @@ class DistributedHierarchization {
 
       // exchange data
       std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      exchangeData1d(dfg, dim, remoteData);
+      exchangeData1d(dfg, dim, remoteData, lmin[dim]);
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        hierarchizeN_opt_boundary(dfg, lookupTable, dim);
+        hierarchizeN_opt_boundary(dfg, lookupTable, dim, lmin[dim]);
       } else {
+        assert(lmin == 0);
         hierarchizeN_opt_noboundary(dfg, lookupTable, dim);
       }
     }
@@ -1860,9 +1901,13 @@ class DistributedHierarchization {
 
   // inplace dehierarchization
   template <typename FG_ELEMENT>
-  static void dehierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims) {
+  static void dehierarchize(DistributedFullGrid<FG_ELEMENT>& dfg, const std::vector<bool>& dims,
+                            LevelVector lmin = LevelVector(0)) {
     assert(dfg.getDimension() > 0);
     assert(dfg.getDimension() == dims.size());
+    if (lmin.size() == 0) {
+      lmin = LevelVector(dims.size(), 0);
+    }
 
     // dehierarchize first dimension
     if (dims[0]) {
@@ -1870,12 +1915,13 @@ class DistributedHierarchization {
 
       // exchange data first dimension
       std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      exchangeData1dDehierarchization(dfg, dim, remoteData);
+      exchangeData1dDehierarchization(dfg, dim, remoteData, lmin[dim]);
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        dehierarchizeX_opt_boundary(dfg, lookupTable);
+        dehierarchizeX_opt_boundary(dfg, lookupTable, lmin[dim]);
       } else {
+        assert(lmin == 0);
         dehierarchizeX_opt_noboundary(dfg, lookupTable);
       }
     }
@@ -1886,12 +1932,13 @@ class DistributedHierarchization {
 
       // exchange data
       std::vector<RemoteDataContainer<FG_ELEMENT> > remoteData;
-      exchangeData1dDehierarchization(dfg, dim, remoteData);
+      exchangeData1dDehierarchization(dfg, dim, remoteData, lmin[dim]);
       LookupTable<FG_ELEMENT> lookupTable(remoteData, dfg, dim);
 
       if (dfg.returnBoundaryFlags()[dim] == true) {
-        dehierarchizeN_opt_boundary(dfg, lookupTable, dim);
+        dehierarchizeN_opt_boundary(dfg, lookupTable, dim, lmin[dim]);
       } else {
+        assert(lmin == 0);
         dehierarchizeN_opt_noboundary(dfg, lookupTable, dim);
       }
     }

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiBasisFunctionBasis.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiBasisFunctionBasis.hpp
@@ -1,6 +1,7 @@
 #ifndef COMBIBASISFUNCTION_HPP_
 #define COMBIBASISFUNCTION_HPP_
 
+#include <boost/serialization/access.hpp>
 #include <sgpp/distributedcombigrid/legacy/combigrid_utils.hpp>
 
 namespace combigrid {
@@ -31,6 +32,12 @@ class BasisFunctionBasis {
    * @param coord  1D coordonate idealy should be [0,1] but for extrapolation
    * could be different [-1,2]*/
   virtual double functionEval2(double coord) const = 0;
+
+ private:
+  friend class boost::serialization::access;
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {}
 };
 }  // namespace combigrid
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiBasisFunctionBasis.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiBasisFunctionBasis.hpp
@@ -16,7 +16,9 @@ namespace combigrid {
 class BasisFunctionBasis {
  public:
   /** empty Ctror */
-  BasisFunctionBasis() { ; }
+  BasisFunctionBasis() = default;
+  /** virtual Dtor */
+  virtual ~BasisFunctionBasis() = default;
 
   /** first method which returns the contribution of the first point in the 1D
    * cell

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.cpp
@@ -1,4 +1,0 @@
-#include <sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp>
-
-const combigrid::BasisFunctionBasis* combigrid::LinearBasisFunction::defaultBasis_ =
-    new combigrid::LinearBasisFunction();

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp
@@ -1,6 +1,7 @@
 #ifndef COMBILINEARBASISFUNCTION_HPP_
 #define COMBILINEARBASISFUNCTION_HPP_
 
+#include <boost/serialization/base_object.hpp>
 #include <sgpp/distributedcombigrid/legacy/CombiBasisFunctionBasis.hpp>
 #include <sgpp/distributedcombigrid/legacy/combigrid_utils.hpp>
 
@@ -28,7 +29,57 @@ class LinearBasisFunction : public combigrid::BasisFunctionBasis {
   // /** return the default basis function*/
   // static const BasisFunctionBasis* getDefaultBasis() { return defaultBasis_; }
  private:
+   // serialize
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<BasisFunctionBasis>(*this);
+  }
 };
+
+/** Linear basis functions (= based on B-splines of first order), but with different hierarchical
+ * increments */
+class HierarchicalHatBasisFunction : public combigrid::LinearBasisFunction {
+  // serialize
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<BasisFunctionBasis>(*this);
+  }
+};
+class FullWeightingBasisFunction : public combigrid::LinearBasisFunction {
+  // serialize
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<BasisFunctionBasis>(*this);
+  }
+};
+class FullWeightingPeriodicBasisFunction : public combigrid::LinearBasisFunction {
+  // serialize
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<BasisFunctionBasis>(*this);
+  }
+};
+class BiorthogonalBasisFunction : public combigrid::LinearBasisFunction {
+  // serialize
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<BasisFunctionBasis>(*this);
+  }
+};
+class BiorthogonalPeriodicBasisFunction : public combigrid::LinearBasisFunction {
+  // serialize
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<BasisFunctionBasis>(*this);
+  }
+};
+
 }  // namespace combigrid
 
 #endif /* COMBILINEARBASISFUNCTION_HPP_ */

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp
@@ -10,26 +10,24 @@ namespace combigrid {
 class LinearBasisFunction : public combigrid::BasisFunctionBasis {
  public:
   /** empty Ctror */
-  LinearBasisFunction() { ; }
+  LinearBasisFunction() = default;
+  virtual ~LinearBasisFunction() = default;
 
   /** first method which returns the contribution of the first point in the 1D
    * cell
    * @param coord  1D coordonate idealy should be [0,1] but for extrapolation
    * could be different [-1,2]*/
-  virtual double functionEval1(double coord) const { return (1.0 - coord); }
+  double functionEval1(double coord) const override { return (1.0 - coord); }
 
   /** second method which returns the contribution of the second point in the 1D
    * cell
    * @param coord  1D coordonate idealy should be [0,1] but for extrapolation
    * could be different [-1,2]*/
-  virtual double functionEval2(double coord) const { return (coord); }
+  double functionEval2(double coord) const override { return (coord); }
 
-  /** return the default basis function*/
-  static const BasisFunctionBasis* getDefaultBasis() { return defaultBasis_; }
-
+  // /** return the default basis function*/
+  // static const BasisFunctionBasis* getDefaultBasis() { return defaultBasis_; }
  private:
-  /** default basis function */
-  static const BasisFunctionBasis* defaultBasis_;
 };
 }  // namespace combigrid
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
@@ -29,13 +29,16 @@ class CombiParameters {
         reduceCombinationDimsLmin_(reduceCombinationDimsLmin),
         reduceCombinationDimsLmax_(reduceCombinationDimsLmax) {
     hierarchizationDims_ = std::vector<bool>(dim_, true);
+    for (DimType d = 0; d < dim_; ++d) {
+      hierarchicalBases_.push_back(new HierarchicalHatBasisFunction());
+    }
     setLevelsCoeffs(taskIDs, levels, coeffs);
     numTasks_ = taskIDs.size();
   }
 
   CombiParameters(DimType dim, LevelVector lmin, LevelVector lmax, std::vector<bool>& boundary,
                   std::vector<LevelVector>& levels, std::vector<real>& coeffs,
-                  std::vector<bool>& hierachizationDims, std::vector<int>& taskIDs,
+                  std::vector<bool>& hierarchizationDims, std::vector<int>& taskIDs,
                   IndexType numberOfCombinations, IndexType numGrids = 1,
                   LevelVector reduceCombinationDimsLmin = std::vector<IndexType>(0),
                   LevelVector reduceCombinationDimsLmax = std::vector<IndexType>(0),
@@ -44,18 +47,26 @@ class CombiParameters {
         lmin_(lmin),
         lmax_(lmax),
         boundary_(boundary),
-        hierarchizationDims_(hierachizationDims),
+        hierarchizationDims_(hierarchizationDims),
         procsSet_(false),
         forwardDecomposition_(forwardDecomposition),
         numberOfCombinations_(numberOfCombinations),
         numGridsPerTask_(numGrids),
         reduceCombinationDimsLmin_(reduceCombinationDimsLmin),
         reduceCombinationDimsLmax_(reduceCombinationDimsLmax) {
+    for (DimType d = 0; d < dim_; ++d) {
+      hierarchicalBases_.push_back(new HierarchicalHatBasisFunction());
+    }
     setLevelsCoeffs(taskIDs, levels, coeffs);
     numTasks_ = taskIDs.size();
   }
 
-  ~CombiParameters() {}
+  ~CombiParameters() {
+    // for (auto& b : hierarchicalBases_) {
+    //   if (b!= nullptr) { delete b; }
+    //   b = nullptr;
+    // }
+  }
 
   inline const LevelVector& getLMin() { return lmin_; }
 
@@ -129,6 +140,41 @@ class CombiParameters {
 
   inline const std::vector<bool>& getHierarchizationDims() { return hierarchizationDims_; }
 
+  /**
+   * @brief Set the Hierarchical Bases object
+   *        set a vector of hierarchicas bases, one for each dimension
+   *        (not necessary if using hierarchical hats in all dimensions)
+   *        Takes over ownership of the contents of the bases object,
+   *        which are assumed to be on the heap
+   */
+  inline void setHierarchicalBases(std::vector<BasisFunctionBasis*>& bases) {
+    assert(bases.size() == dim_);
+    // delete old hierarchicalBases_
+    for (auto& b : hierarchicalBases_) {
+      if (b!= nullptr) { delete b; }
+      b = nullptr;
+    }
+    for (size_t i = 0; i < bases.size(); ++i) {
+      if (bases[i] == nullptr) {
+        assert(hierarchizationDims_[i] == false);
+      }
+      hierarchicalBases_[i] =bases[i];
+      bases[i] = nullptr;
+    }
+  }
+
+  /**
+   * @brief Get the hierarchical bases, one for each dimension
+   *        (assuming all the dfgs are using the same number of dimensions and the same bases)
+   *
+   * @return std::vector<BasisFunctionBasis*> pointers of the type of basis function
+   *          may be nullptr or anything for a non-hierarchization dimension
+   */
+  inline const std::vector<BasisFunctionBasis*>& getHierarchicalBases() {
+    assert(hierarchicalBases_.size() == dim_);
+    return hierarchicalBases_;
+  }
+
   /* get the common parallelization
    * this function can only be used in the uniform mode
    */
@@ -179,6 +225,8 @@ class CombiParameters {
 
   std::vector<bool> hierarchizationDims_;
 
+  std::vector<BasisFunctionBasis*> hierarchicalBases_;
+
   IndexVector procs_;
 
   bool procsSet_;
@@ -224,6 +272,7 @@ void CombiParameters::serialize(Archive& ar, const unsigned int version) {
   ar& levels_;
   ar& coeffs_;
   ar& hierarchizationDims_;
+  ar& hierarchicalBases_;
   ar& procs_;
   ar& procsSet_;
   ar& forwardDecomposition_;
@@ -233,6 +282,18 @@ void CombiParameters::serialize(Archive& ar, const unsigned int version) {
   ar& reduceCombinationDimsLmin_;
   ar& reduceCombinationDimsLmax_;
 }
+
+
+template<typename T>
+void setCombiParametersHierarchicalBasesUniform(CombiParameters& combiParameters) {
+  std::vector<BasisFunctionBasis*> bases;
+  for (DimType d = 0; d < combiParameters.getDim(); ++d) {
+    bases.push_back(new T());
+  }
+  assert(bases.size() == combiParameters.getDim());
+  combiParameters.setHierarchicalBases(bases);
+}
+
 }
 
 #endif /* SRC_SGPP_COMBIGRID_MANAGER_COMBIPARAMETERS_HPP_ */

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
@@ -285,7 +285,7 @@ void CombiParameters::serialize(Archive& ar, const unsigned int version) {
 
 
 template<typename T>
-void setCombiParametersHierarchicalBasesUniform(CombiParameters& combiParameters) {
+static void setCombiParametersHierarchicalBasesUniform(CombiParameters& combiParameters) {
   std::vector<BasisFunctionBasis*> bases;
   for (DimType d = 0; d < combiParameters.getDim(); ++d) {
     bases.push_back(new T());
@@ -294,6 +294,23 @@ void setCombiParametersHierarchicalBasesUniform(CombiParameters& combiParameters
   combiParameters.setHierarchicalBases(bases);
 }
 
+inline static void setCombiParametersHierarchicalBasesUniform(CombiParameters& combiParameters,
+                                                std::string basisName) {
+  if (basisName == "hat") {
+    setCombiParametersHierarchicalBasesUniform<HierarchicalHatBasisFunction>(combiParameters);
+  } else if (basisName == "fullweighting") {
+    setCombiParametersHierarchicalBasesUniform<FullWeightingBasisFunction>(combiParameters);
+  } else if (basisName == "fullweighting_periodic") {
+    setCombiParametersHierarchicalBasesUniform<FullWeightingPeriodicBasisFunction>(combiParameters);
+  } else if (basisName == "biorthogonal") {
+    setCombiParametersHierarchicalBasesUniform<BiorthogonalBasisFunction>(combiParameters);
+  } else if (basisName == "biorthogonal_periodic") {
+    setCombiParametersHierarchicalBasesUniform<BiorthogonalPeriodicBasisFunction>(combiParameters);
+  } else {
+    throw std::invalid_argument("Hierarchical basis string not known.");
+  }
 }
+
+}  // namespace combigrid
 
 #endif /* SRC_SGPP_COMBIGRID_MANAGER_COMBIPARAMETERS_HPP_ */

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
@@ -580,7 +580,7 @@ void ProcessGroupWorker::hierarchizeFullGrids() {
 
       // hierarchize dfg
       DistributedHierarchization::hierarchize<CombiDataType>(
-          dfg, combiParameters_.getHierarchizationDims());
+          dfg, combiParameters_.getHierarchizationDims(), combiParameters_.getHierarchicalBases());
     }
   }
 }
@@ -671,8 +671,10 @@ LevelVector ProcessGroupWorker::receiveLevalAndBroadcast(){
   return leval;
 }
 
-void ProcessGroupWorker::fillDFGFromDSGU(DistributedFullGrid<CombiDataType>& dfg, IndexType g){
-  DistributedHierarchization::fillDFGFromDSGU(dfg, *combinedUniDSGVector_[g], combiParameters_.getHierarchizationDims());
+void ProcessGroupWorker::fillDFGFromDSGU(DistributedFullGrid<CombiDataType>& dfg, IndexType g) {
+  DistributedHierarchization::fillDFGFromDSGU(dfg, *combinedUniDSGVector_[g],
+                                              combiParameters_.getHierarchizationDims(),
+                                              combiParameters_.getHierarchicalBases());
 }
 
 void ProcessGroupWorker::parallelEvalUniform() {
@@ -999,7 +1001,9 @@ void ProcessGroupWorker::setCombinedSolutionUniform(Task* t) {
     // get handle to dfg
     DistributedFullGrid<CombiDataType>& dfg = t->getDistributedFullGrid(g);
 
-    DistributedHierarchization::fillDFGFromDSGU(dfg, *combinedUniDSGVector_[g], combiParameters_.getHierarchizationDims());
+    DistributedHierarchization::fillDFGFromDSGU(dfg, *combinedUniDSGVector_[g],
+                                                combiParameters_.getHierarchizationDims(),
+                                                combiParameters_.getHierarchicalBases());
   }
 }
 
@@ -1027,7 +1031,9 @@ void ProcessGroupWorker::updateTaskWithCurrentValues(Task& taskToUpdate, size_t 
       // get handle to dfg
       DistributedFullGrid<CombiDataType>& dfg = taskToUpdate.getDistributedFullGrid(g);
 
-      DistributedHierarchization::fillDFGFromDSGU(dfg, *combinedUniDSGVector_[g], combiParameters_.getHierarchizationDims());
+      DistributedHierarchization::fillDFGFromDSGU(dfg, *combinedUniDSGVector_[g],
+                                                  combiParameters_.getHierarchizationDims(),
+                                                  combiParameters_.getHierarchicalBases());
 
       // std::vector<CombiDataType> datavector(dfg.getElementVector());
       // afterCombi = datavector;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/BoostExports.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/BoostExports.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <boost/serialization/export.hpp>
+
+#include "sgpp/distributedcombigrid/fault_tolerance/FaultCriterion.hpp"
+#include "sgpp/distributedcombigrid/fault_tolerance/StaticFaults.hpp"
+#include "sgpp/distributedcombigrid/fault_tolerance/WeibullFaults.hpp"
+#include "sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp"
+
+// this header should be included once for every compilation unit; if there are
+// "not registered" or "not exported"-type errors, maybe this header was called before all
+// the relevant fixtures were included?
+// for serializable classes outside the library libsgppdistributedcombigrid, each compilation unit
+// needs to call BOOST_CLASS_EXPORT for those classes.
+
+BOOST_CLASS_EXPORT(combigrid::BasisFunctionBasis)
+BOOST_CLASS_EXPORT(combigrid::LinearBasisFunction)
+// BOOST_CLASS_EXPORT(combigrid::HierarchicalHatBasisFunction);
+// cf. https://www.boost.org/doc/libs/1_71_0/libs/serialization/doc/serialization.html#export
+// BOOST_CLASS_EXPORT_GUID(combigrid::LinearBasisFunction, "LinearBasisFunction")
+// BOOST_CLASS_EXPORT(combigrid::HierarchicalHatBasisFunction);
+BOOST_CLASS_EXPORT_GUID(combigrid::HierarchicalHatBasisFunction, "HierarchicalHatBasisFunction")
+BOOST_CLASS_EXPORT_GUID(combigrid::FullWeightingBasisFunction, "FullWeightingBasisFunction")
+BOOST_CLASS_EXPORT_GUID(combigrid::FullWeightingPeriodicBasisFunction,
+                        "FullWeightingPeriodicBasisFunction")
+BOOST_CLASS_EXPORT_GUID(combigrid::BiorthogonalBasisFunction, "BiorthogonalBasisFunction")
+BOOST_CLASS_EXPORT_GUID(combigrid::BiorthogonalPeriodicBasisFunction,
+                        "BiorthogonalPeriodicBasisFunction")
+
+BOOST_CLASS_EXPORT(combigrid::FaultCriterion)
+BOOST_CLASS_EXPORT(combigrid::StaticFaults)
+BOOST_CLASS_EXPORT(combigrid::WeibullFaults)

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/IndexVector.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/IndexVector.hpp
@@ -6,6 +6,7 @@
 #include <ostream>
 #include <vector>
 #include <map>
+#include <set>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -164,6 +165,18 @@ inline std::ostream &operator <<(std::ostream &os, const std::map<T, U> &m) {
   for (const auto& any : m) {
     os << "(" << any.first << ") : " << any.second << "; ";
   }
+  return os;
+}
+
+// helper function to output any set
+template<typename T>
+inline std::ostream &operator <<(std::ostream &os, const std::set<T> &s) {
+  using namespace std;
+  os << "[";
+  for (const auto& any : s) {
+    os << any << ", ";
+  }
+  os << "]";
   return os;
 }
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/IndexVector.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/IndexVector.hpp
@@ -153,7 +153,10 @@ template<typename T>
 inline std::ostream &operator <<(std::ostream &os, const std::vector<T> &v) {
   using namespace std;
   os << "[";
-  copy(v.begin(), v.end(), ostream_iterator<T>(os, ", "));
+  // copy(v.begin(), v.end(), ostream_iterator<T>(os, ", "));
+  for (const auto& any : v) {
+    os << any << " ";
+  }
   os << "]";
   return os;
 }

--- a/distributedcombigrid/tests/test_distributedfullgrid.cpp
+++ b/distributedcombigrid/tests/test_distributedfullgrid.cpp
@@ -255,13 +255,19 @@ void checkDistributedFullgrid(LevelVector& levels, IndexVector& procs, std::vect
     dfgCopy.getData()[li] = dfg.getData()[li];
   }
   BOOST_TEST_CHECKPOINT("copied to dfgCopy");
+
+  auto formerCorners = dfg.getCornersValues();
+  auto formerBoundaryAvgValue =
+      std::accumulate(formerCorners.begin(), formerCorners.end(),
+                      static_cast<std::complex<double>>(0.), std::plus<std::complex<double>>()) /
+      static_cast<double>(formerCorners.size());
   // test averageBoundaryValues
   dfgCopy.averageBoundaryValues();
   if (std::all_of(boundary.begin(), boundary.end(), [](bool b) { return b; })) {
     // assert that all the corners values are the same now
     auto cornersValues = dfgCopy.getCornersValues();
     for (const auto& cornerValue : cornersValues) {
-      BOOST_TEST(cornerValue == cornersValues[0]);
+      BOOST_TEST(cornerValue == formerBoundaryAvgValue);
     }
   }
 

--- a/distributedcombigrid/tests/test_distributedfullgrid.cpp
+++ b/distributedcombigrid/tests/test_distributedfullgrid.cpp
@@ -180,15 +180,22 @@ void checkDistributedFullgrid(LevelVector& levels, IndexVector& procs, std::vect
   auto onenorm = dfg.getLpNorm(1);
   auto twonorm = dfg.getLpNorm(2);
   if (std::all_of(boundary.begin(), boundary.end(), [](bool i){return i;})){
+    // check that InnerNodalBasisFunctionIntegral is correct
+    double numFullInnerBasisFcns = 1.;
+    for (DimType d = 0; d < dim; ++d) {
+      numFullInnerBasisFcns *= static_cast<double>(dfg.length(d) - 1);
+    }
+    BOOST_CHECK_CLOSE(dfg.getInnerNodalBasisFunctionIntegral(), 1./numFullInnerBasisFcns, TestHelper::tolerance);
+
     std::vector<double> maxcoords(dim, 1.);
     BOOST_CHECK_EQUAL(f(maxcoords), maxnorm);
+    // solution is a hyperplane, so the L1 norm is equal to the value in the middle
+    std::vector<double> middlecoords(dim, 0.5);
+    BOOST_CHECK_CLOSE(std::abs(f(middlecoords)), onenorm, TestHelper::tolerance);
   }
-  // solution is a hyperplane, so the sum is equal to the value in the middle times the number of points
-  std::vector<double> middlecoords(dim, 0.5);
-  BOOST_CHECK_EQUAL(f(middlecoords)*static_cast<double>(dfg.getNrElements()), onenorm);
   // lazy for the two-norm, just check boundedness relations:
   BOOST_CHECK(twonorm <= onenorm);
-  BOOST_CHECK(onenorm <= std::sqrt(dfg.getNrElements())*twonorm);
+  BOOST_CHECK(onenorm <= maxnorm);
 
   // test ghost layer exchange
   IndexVector subarrayExtents;
@@ -260,7 +267,7 @@ void checkDistributedFullgrid(LevelVector& levels, IndexVector& procs, std::vect
           if (!edge){
             // check if the value is the same as on the lower boundary
             auto compareCoords = coords;
-            compareCoords[d] = 0;
+            compareCoords[d] = 0.;
             BOOST_CHECK_EQUAL(dfg.getElementVector()[i], f(compareCoords));
           }
         } else {
@@ -287,9 +294,16 @@ BOOST_AUTO_TEST_SUITE(distributedfullgrid, *boost::unit_test::timeout(60))
 // with boundary
 // isotropic
 
-BOOST_AUTO_TEST_CASE(test_minus2) {
+BOOST_AUTO_TEST_CASE(test_minus3) {
   BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(1));
   LevelVector levels = {1, 2};
+  IndexVector procs = {1, 1};
+  std::vector<bool> boundary(2, true);
+  checkDistributedFullgrid(levels, procs, boundary, 1);
+}
+BOOST_AUTO_TEST_CASE(test_minus2) {
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(1));
+  LevelVector levels = {2, 3};
   IndexVector procs = {1, 1};
   std::vector<bool> boundary(2, true);
   checkDistributedFullgrid(levels, procs, boundary, 1);

--- a/distributedcombigrid/tests/test_ftolerance.cpp
+++ b/distributedcombigrid/tests/test_ftolerance.cpp
@@ -16,6 +16,7 @@
 #include "sgpp/distributedcombigrid/task/Task.hpp"
 #include "sgpp/distributedcombigrid/utils/Types.hpp"
 #include "sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp"
+#include "sgpp/distributedcombigrid/legacy/CombiLinearBasisFunction.hpp"
 #include "sgpp/distributedcombigrid/fullgrid/FullGrid.hpp"
 #include "sgpp/distributedcombigrid/loadmodel/LinearLoadModel.hpp"
 #include "sgpp/distributedcombigrid/loadmodel/LearningLoadModel.hpp"
@@ -32,6 +33,8 @@
 #include "sgpp/distributedcombigrid/fault_tolerance/FTUtils.hpp"
 #include "sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp"
 
+// this is necessary for correct function of task serialization
+#include "sgpp/distributedcombigrid/utils/BoostExports.hpp"
 
 using namespace combigrid;
 
@@ -200,11 +203,6 @@ class TaskAdvFDM : public combigrid::Task {
 
 // this is necessary for correct function of task serialization
 BOOST_CLASS_EXPORT(TaskAdvFDM)
-BOOST_CLASS_EXPORT(StaticFaults)
-BOOST_CLASS_EXPORT(WeibullFaults)
-
-BOOST_CLASS_EXPORT(FaultCriterion)
-
 
 void checkFtolerance(bool useCombine, bool useFG, double l0err, double l2err, size_t ncombi, int nfaults,int iteration_faults, int global_rank_faults) {
   

--- a/distributedcombigrid/tests/test_helper.hpp
+++ b/distributedcombigrid/tests/test_helper.hpp
@@ -42,10 +42,19 @@ namespace TestHelper{
     if (flag){
       int number_amount;
       MPI_Get_count(&status, MPI_CHAR, &number_amount);
-      std::cout << getRank(MPI_COMM_WORLD) << " received " << number_amount << " from " << status.MPI_SOURCE << " with tag " << status.MPI_TAG << std::endl;
+      std::cout << getRank(MPI_COMM_WORLD) << " received " << number_amount << " from "
+                << status.MPI_SOURCE << " with tag " << status.MPI_TAG << std::endl;
     }
     BOOST_CHECK(flag == false);
   }
-}
+
+  struct BarrierAtEnd {
+    BarrierAtEnd() = default;
+    ~BarrierAtEnd() {
+      MPI_Barrier(MPI_COMM_WORLD);
+      TestHelper::testStrayMessages();
+    }
+  };
+}  // namespace TestHelper
 
 #endif  // TEST_HELPER_HPP

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -322,7 +322,7 @@ void checkHierarchization(Functor& f, DistributedFullGrid<std::complex<double>>&
   }
 }
 
-BOOST_AUTO_TEST_SUITE(hierarchization, *boost::unit_test::timeout(120))
+BOOST_AUTO_TEST_SUITE(hierarchization, *boost::unit_test::timeout(240))
 
 // with boundary
 // isotropic

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -207,6 +207,15 @@ BOOST_AUTO_TEST_SUITE(hierarchization, *boost::unit_test::timeout(120))
 // with boundary
 // isotropic
 
+BOOST_AUTO_TEST_CASE(test_0) {
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(1));
+  LevelVector levels = {4, 4, 4};
+  IndexVector procs = {1, 1, 1};
+  std::vector<bool> boundary(3, true);
+  TestFn_1 testFn(levels);
+  checkHierarchization(testFn, levels, procs, boundary, 1);
+}
+
 BOOST_AUTO_TEST_CASE(test_1) {
   BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(8));
   LevelVector levels = {4, 4, 4};

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -132,7 +132,7 @@ class TestFn_3 {
 template <typename Functor>
 void checkHierarchization(Functor& f, LevelVector& levels, IndexVector& procs,
                           std::vector<bool>& boundary, int size, bool forward = false,
-                          bool checkValues = true) {
+                          bool checkValues = true, LevelVector lmin = LevelVector(0)) {
   CommunicatorType comm = TestHelper::getComm(size);
   if (comm == MPI_COMM_NULL) return;
 
@@ -154,30 +154,62 @@ void checkHierarchization(Functor& f, LevelVector& levels, IndexVector& procs,
     fg.getCoords(i, coords);
     fg.getData()[i] = f(coords);
   }
+  auto fgCopy = fg;
 
   // hierarchize fg and distributed fg
   Hierarchization::hierarchize(fg);
-  DistributedHierarchization::hierarchize(dfg);
+  DistributedHierarchization::hierarchize(dfg, std::vector<bool>(dim, true), lmin);
 
   if (checkValues) {
-    // compare hierarchical surpluses
-    for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
-      IndexType gi = dfg.getGlobalLinearIndex(li);
+    if (lmin.size() > 0) {
+      for (size_t i = 0; i < levels.size(); ++i) {
+        assert(lmin[i] <= levels[i]);
+      }
+      LevelVector levels_of_point(dim);
+      IndexVector tmp(dim);
       IndexVector axisIndex(dim);
-      fg.getVectorIndex(gi, axisIndex);
+      for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
+        IndexType gi = dfg.getGlobalLinearIndex(li);
+        dfg.getGlobalLI(gi, levels_of_point, tmp);
 
-      // compare fg and distributed fg
-      BOOST_TEST(dfg.getData()[li] == fg.getData()[gi],
-                 boost::test_tools::tolerance(TestHelper::tolerance));
-      // compare distributed fg to exact solution
-      BOOST_TEST(dfg.getData()[li] == f(axisIndex),
-                 boost::test_tools::tolerance(TestHelper::tolerance));
+        if(levels_of_point > lmin) {
+          fg.getVectorIndex(gi, axisIndex);
+          // the finest levels up to lmin should always be hierarchized
+          // compare hierarchical surpluses
+          // compare fg and distributed fg
+          BOOST_TEST(dfg.getData()[li] == fg.getData()[gi],
+                    boost::test_tools::tolerance(TestHelper::tolerance));
+          // compare distributed fg to exact solution
+          BOOST_TEST(dfg.getData()[li] == f(axisIndex),
+                    boost::test_tools::tolerance(TestHelper::tolerance));
+        } else if (levels_of_point <= lmin){
+          // the coarsest levels should not be hierarchized at all
+          fg.getVectorIndex(gi, axisIndex);
+          // compare non-hierarchized fg and distributed fg
+          BOOST_TEST(dfg.getData()[li] == fgCopy.getData()[gi],
+                    boost::test_tools::tolerance(TestHelper::tolerance));
+        }
+      }
+    } else {
+      // compare hierarchical surpluses
+      for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
+        IndexType gi = dfg.getGlobalLinearIndex(li);
+        IndexVector axisIndex(dim);
+        fg.getVectorIndex(gi, axisIndex);
+
+        // compare fg and distributed fg
+        BOOST_TEST(dfg.getData()[li] == fg.getData()[gi],
+                  boost::test_tools::tolerance(TestHelper::tolerance));
+        // compare distributed fg to exact solution
+        BOOST_TEST(dfg.getData()[li] == f(axisIndex),
+                  boost::test_tools::tolerance(TestHelper::tolerance));
+      }
     }
   }
 
   // dehiarchize fg and distributed fg
   Hierarchization::dehierarchize(fg);
-  DistributedHierarchization::dehierarchize(dfg);
+  DistributedHierarchization::dehierarchize(dfg, std::vector<bool>(dim, true), lmin);
 
   if (checkValues) {
     // compare function values
@@ -561,6 +593,7 @@ BOOST_AUTO_TEST_CASE(test_41) {
   TestFn_3 testFn(levels);
   checkHierarchization(testFn, levels, procs, boundary, 9, true);
 }
+
 BOOST_AUTO_TEST_CASE(test_42) {
   // large test case with timing
   MPI_Barrier(MPI_COMM_WORLD);
@@ -575,6 +608,58 @@ BOOST_AUTO_TEST_CASE(test_42) {
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   BOOST_TEST_MESSAGE("hierarchization time: " << duration.count() << " milliseconds");
   // on ipvs-epyc@6cddd9a0b8a4: 5100 milliseconds
+  // on ipvs-epyc@: 5600 milliseconds
+}
+
+// test for lmin
+BOOST_AUTO_TEST_CASE(test_43) {
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(1));
+  LevelVector levels = {4, 4, 4, 4, 4};
+  IndexVector procs = {1, 1, 1, 1, 1};
+  std::vector<bool> boundary(5, true);
+  TestFn_1 testFn(levels);
+  checkHierarchization(testFn, levels, procs, boundary, 1, false, true, {4, 3, 2, 1, 0});
+}
+// BOOST_AUTO_TEST_CASE(test_44) {
+//   BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(8));
+//   LevelVector levels = {2, 1, 3, 3, 2};
+//   IndexVector procs = {2, 1, 2, 2, 1};
+//   std::vector<bool> boundary(5, false); //TODO not yet implemented for no boundary
+//   TestFn_3 testFn(levels);
+//   checkHierarchization(testFn, levels, procs, boundary, 8, false, true, {2, 1, 2, 1, 1});
+// }
+BOOST_AUTO_TEST_CASE(test_45) {
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(9));
+  LevelVector levels = {2, 3, 4};
+  IndexVector procs = {3, 3, 1};
+  std::vector<bool> boundary(3, true);
+  TestFn_3 testFn(levels);
+  checkHierarchization(testFn, levels, procs, boundary, 9, true, true, {2,2,2});
+}
+BOOST_AUTO_TEST_CASE(test_46) {
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(8));
+  LevelVector levels = {8, 7, 6};
+  IndexVector procs = {4, 2, 1};
+  std::vector<bool> boundary(3, true);
+  TestFn_3 testFn(levels);
+  checkHierarchization(testFn, levels, procs, boundary, 8, true, true, {6, 5, 1});
+}
+
+
+BOOST_AUTO_TEST_CASE(test_47) {
+  // large test case with timing
+  MPI_Barrier(MPI_COMM_WORLD);
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(8));
+  LevelVector levels = {11, 11, 4};
+  IndexVector procs = {2,2,2};
+  std::vector<bool> boundary(3, true);
+  TestFn_3 testFn(levels);
+  auto start = std::chrono::high_resolution_clock::now();
+  checkHierarchization(testFn, levels, procs, boundary, 8, true, false, {6, 5, 1});
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  BOOST_TEST_MESSAGE("hierarchization time: " << duration.count() << " milliseconds");
+  // on ipvs-epyc@: 5500 milliseconds
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -128,6 +128,102 @@ class TestFn_3 {
     return result;
   }
 };
+// TODO remove duplicate code
+template <typename Functor>
+void checkBiorthogonalHierarchization(Functor& f, DistributedFullGrid<std::complex<double>>& dfg,
+                                      bool checkValues = true) {
+  auto dim = dfg.getDimension();
+  // create distributed fg and copy values
+  DistributedFullGrid<std::complex<double>> dfgCopy(
+      dim, dfg.getLevels(), dfg.getCommunicator(), dfg.returnBoundaryFlags(),
+      dfg.getParallelization(), true, dfg.getDecomposition());
+  for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
+    dfgCopy.getData()[li] = dfg.getData()[li];
+  }
+
+  std::vector<bool> hierarchizationDimensions(dim, true);
+  DistributedHierarchization::hierarchizeBiorthogonal<std::complex<double>>(
+      dfgCopy, hierarchizationDimensions);
+
+  // now, all of the mass should be on the coarsest level -> the corners
+  if (checkValues) {
+    const auto innerIntegral = dfg.getInnerNodalBasisFunctionIntegral();
+    // calculate discrete analytical l1
+    double analyticalL1 = 0.;
+    for (IndexType gli = 0; gli < dfg.getNrElements(); ++gli) {
+      auto isOnBoundary = dfg.isGlobalLinearIndexOnBoundary(gli);
+      auto countBoundary = std::count(isOnBoundary.begin(), isOnBoundary.end(), true);
+      double hatFcnIntegral = oneOverPowOfTwo[countBoundary];
+      std::vector<double> coords(dim);
+      dfg.getCoordsGlobal(gli, coords);
+      analyticalL1 += std::abs(f(coords)) * hatFcnIntegral;
+    }
+    analyticalL1 *= innerIntegral;
+    // calculate l1 integral of actual data
+    auto formerL1 = dfg.getLpNorm(1);
+    BOOST_TEST(formerL1 == analyticalL1, boost::test_tools::tolerance(TestHelper::tolerance));
+    auto cornersValues = dfgCopy.getCornersValues();
+    BOOST_CHECK(cornersValues.size() == powerOfTwo[dim]);
+    auto sumOfCornerValues =
+        std::accumulate(cornersValues.begin(), cornersValues.end(), std::complex<double>(0.),
+                        std::plus<std::complex<double>>());
+    auto currentL1 = std::abs(sumOfCornerValues * oneOverPowOfTwo[dim]);
+    BOOST_TEST(currentL1 == formerL1, boost::test_tools::tolerance(TestHelper::tolerance));
+  }
+
+  DistributedHierarchization::dehierarchizeBiorthogonal<std::complex<double>>(
+      dfgCopy, hierarchizationDimensions);
+
+  if (checkValues) {
+    // compare dfgCopy to former values
+    for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
+      BOOST_TEST(dfgCopy.getData()[li] == dfg.getData()[li],
+                 boost::test_tools::tolerance(TestHelper::tolerance));
+    }
+  }
+}
+
+template <typename Functor>
+void checkFullWeightingHierarchization(Functor& f, DistributedFullGrid<std::complex<double>>& dfg,
+                                       bool checkValues = true) {
+  auto dim = dfg.getDimension();
+  // create distributed fg and copy values
+  DistributedFullGrid<std::complex<double>> dfgCopy(
+      dim, dfg.getLevels(), dfg.getCommunicator(), dfg.returnBoundaryFlags(),
+      dfg.getParallelization(), true, dfg.getDecomposition());
+  for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
+    dfgCopy.getData()[li] = dfg.getData()[li];
+  }
+
+  std::vector<bool> hierarchizationDimensions(dim, true);
+  DistributedHierarchization::hierarchizeFullWeighting<std::complex<double>>(
+      dfgCopy, hierarchizationDimensions);
+
+  // now, all of the mass should be on the coarsest level -> the corners
+  if (checkValues) {
+    // calculate l1 integral of actual data
+    auto formerL1 = dfg.getLpNorm(1);
+    auto cornersValues = dfgCopy.getCornersValues();
+    BOOST_CHECK(cornersValues.size() == powerOfTwo[dim]);
+
+    auto sumOfCornerValues =
+        std::accumulate(cornersValues.begin(), cornersValues.end(), std::complex<double>(0.),
+                        std::plus<std::complex<double>>());
+    auto currentL1 = std::abs(sumOfCornerValues * oneOverPowOfTwo[dim]);
+    BOOST_TEST(currentL1 == formerL1, boost::test_tools::tolerance(TestHelper::tolerance));
+  }
+
+  DistributedHierarchization::dehierarchizeFullWeighting<std::complex<double>>(
+      dfgCopy, hierarchizationDimensions);
+
+  if (checkValues) {
+    // compare dfgCopy to former values
+    for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {
+      BOOST_TEST(dfgCopy.getData()[li] == dfg.getData()[li],
+                 boost::test_tools::tolerance(TestHelper::tolerance));
+    }
+  }
+}
 
 template <typename Functor>
 void checkHierarchization(Functor& f, LevelVector& levels, IndexVector& procs,
@@ -198,6 +294,17 @@ void checkHierarchization(Functor& f, LevelVector& levels, IndexVector& procs,
       // compare distributed fg and fg to exact solution
       BOOST_TEST(dfg.getData()[li] == f(coords_fg),
                  boost::test_tools::tolerance(TestHelper::tolerance));
+    }
+  }
+
+  // call this here so that tests are also run for mass-conserving bases
+  // but only for boundary grids and in case we are not measuring time
+  if (checkValues && std::all_of(boundary.begin(), boundary.end(), [](bool b) { return b; })) {
+    if (!(typeid(Functor) == typeid(TestFn_3))) {
+      // TODO figure out what is supposed to happen for true complex numbers,
+      // currently std::abs does not seem to do the right thing
+      checkFullWeightingHierarchization(f, dfg, true);
+      checkBiorthogonalHierarchization(f, dfg, true);
     }
   }
 }

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -207,6 +207,7 @@ BOOST_AUTO_TEST_SUITE(hierarchization, *boost::unit_test::timeout(120))
 // with boundary
 // isotropic
 
+// the most basic case with a single worker
 BOOST_AUTO_TEST_CASE(test_0) {
   BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(1));
   LevelVector levels = {4, 4, 4};
@@ -214,6 +215,16 @@ BOOST_AUTO_TEST_CASE(test_0) {
   std::vector<bool> boundary(3, true);
   TestFn_1 testFn(levels);
   checkHierarchization(testFn, levels, procs, boundary, 1);
+}
+
+// 2D case with 4 workers
+BOOST_AUTO_TEST_CASE(test_05) {
+  BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(4));
+  LevelVector levels = {2,2,};
+  IndexVector procs = {2,2};
+  std::vector<bool> boundary(2, true);
+  TestFn_1 testFn(levels);
+  checkHierarchization(testFn, levels, procs, boundary, 4);
 }
 
 BOOST_AUTO_TEST_CASE(test_1) {

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -4,6 +4,7 @@
 #include <complex>
 #include <cstdarg>
 #include <iostream>
+#include <typeinfo>
 #include <vector>
 
 #include "sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp"
@@ -686,7 +687,7 @@ BOOST_AUTO_TEST_CASE(test_42) {
   LevelVector levels = {11, 11, 4};
   IndexVector procs = {2,2,2};
   std::vector<bool> boundary(3, true);
-  TestFn_3 testFn(levels);
+  TestFn_1 testFn(levels);
   auto start = std::chrono::high_resolution_clock::now();
   checkHierarchization(testFn, levels, procs, boundary, 8, true, false);
   auto end = std::chrono::high_resolution_clock::now();

--- a/distributedcombigrid/tests/test_integration.cpp
+++ b/distributedcombigrid/tests/test_integration.cpp
@@ -219,7 +219,7 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
 }
 
 #ifndef ISGENE // integration tests won't work with ISGENE because of worker magic
-BOOST_AUTO_TEST_SUITE(integration, *boost::unit_test::timeout(120))
+BOOST_FIXTURE_TEST_SUITE(integration, TestHelper::BarrierAtEnd, *boost::unit_test::timeout(120))
 
 BOOST_AUTO_TEST_CASE(test_1, *boost::unit_test::tolerance(TestHelper::higherTolerance) ) {
   for (bool boundary : {true}) {
@@ -238,9 +238,6 @@ BOOST_AUTO_TEST_CASE(test_1, *boost::unit_test::tolerance(TestHelper::higherTole
       }
     }
   }
-
-  MPI_Barrier(MPI_COMM_WORLD);
-  TestHelper::testStrayMessages();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/distributedcombigrid/tests/test_integration.cpp
+++ b/distributedcombigrid/tests/test_integration.cpp
@@ -147,8 +147,8 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
     manager.combine();
     std::cout << "combined " << ngroup << " " << nprocs << std::endl;
 
-    BOOST_TEST_CHECKPOINT("write solution");
     std::string filename("integration_" + std::to_string(ncombi) + ".raw");
+    BOOST_TEST_CHECKPOINT("write solution " + filename);
     Stats::startEvent("manager write solution");
     manager.parallelEval( lmax, filename, 0 );
     Stats::stopEvent("manager write solution");
@@ -219,7 +219,7 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
 }
 
 #ifndef ISGENE // integration tests won't work with ISGENE because of worker magic
-BOOST_AUTO_TEST_SUITE(integration, *boost::unit_test::timeout(60))
+BOOST_AUTO_TEST_SUITE(integration, *boost::unit_test::timeout(120))
 
 BOOST_AUTO_TEST_CASE(test_1, *boost::unit_test::tolerance(TestHelper::higherTolerance) ) {
   for (bool boundary : {true}) {

--- a/distributedcombigrid/tests/test_mpisystem.cpp
+++ b/distributedcombigrid/tests/test_mpisystem.cpp
@@ -145,9 +145,9 @@ BOOST_AUTO_TEST_CASE(test_1, *boost::unit_test::timeout(60)) {
     vmSizes[i] = checkMPIMemory(1, groupSizes[i]);
     if (i > 0) {
       // compare allocated memory sizes
-      // check for linear scaling (grace 10%)
+      // check for linear scaling (grace 20%)
       if (TestHelper::getRank(MPI_COMM_WORLD) == 0) {
-        BOOST_TEST(static_cast<double>(vmSizes[i]) <= (vmSizes[0] * groupSizes[i] / groupSizes[0] * 1.1));
+        BOOST_TEST(static_cast<double>(vmSizes[i]) <= (vmSizes[0] * groupSizes[i] / groupSizes[0] * 1.2));
       }
     }
   }


### PR DESCRIPTION
- removed some code duplication and clutter
- added different mass-conserving hierarchization and dehierarchization operators (currently only for one process for testing purposes, since multiple processes need a multi-recursive communication of point values due to stencilization)
- added the possibility to specify a minimum level for hierarchization, and then removed it again because it actually made the code slower (I believe due to all the level checks). Please do not fast-forward merge this in case a minimum level seems sensible in the future!