### PR TITLE
Ready for Terascale

### DIFF
--- a/distributedcombigrid/examples/combi_example/combi_example.cpp
+++ b/distributedcombigrid/examples/combi_example/combi_example.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
 
     // create Tasks
     TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
     for (size_t i = 0; i < levels.size(); i++) {
       Task* t = new TaskExample(dim, levels[i], boundary, coeffs[i], loadmodel.get(), dt, nsteps, p);
       tasks.push_back(t);

--- a/distributedcombigrid/examples/combi_example_faults/combi_example_faults.cpp
+++ b/distributedcombigrid/examples/combi_example_faults/combi_example_faults.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
 
     /* create Tasks */
     TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
 
     for (size_t i = 0; i < levels.size(); i++) {
       //create FaultCriterion

--- a/distributedcombigrid/examples/gene_distributed/src/manager.cpp
+++ b/distributedcombigrid/examples/gene_distributed/src/manager.cpp
@@ -293,7 +293,7 @@ int main(int argc, char** argv) {
   // not work properly
   std::vector<LevelVector> levels;
   std::vector<combigrid::real> coeffs;
-  std::vector<int> fileTaskIDs;
+  std::vector<size_t> fileTaskIDs;
 
   const bool READ_FROM_FILE = cfg.get<bool>("ct.readspaces");
   if (READ_FROM_FILE) { //currently used file produced by preproc.py
@@ -340,7 +340,7 @@ int main(int argc, char** argv) {
 
   // create Tasks
   TaskContainer tasks;
-  std::vector<int> taskIDs;
+  std::vector<size_t> taskIDs;
 
   //initialize individual tasks (component grids)
   for (size_t i = 0; i < levels.size(); i++) {

--- a/distributedcombigrid/examples/gene_distributed_linear/src/manager.cpp
+++ b/distributedcombigrid/examples/gene_distributed_linear/src/manager.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
     // not work properly
     std::vector<LevelVector> levels;
     std::vector<combigrid::real> coeffs;
-    std::vector<int> fileTaskIDs;
+    std::vector<size_t> fileTaskIDs;
     const bool READ_FROM_FILE = cfg.get<bool>("ct.readspaces");
     if (READ_FROM_FILE) { //currently used file produced by preproc.py
       std::ifstream spcfile("spaces.dat");
@@ -251,7 +251,7 @@ int main(int argc, char** argv) {
 
     // create Tasks
     TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
 
     //initialize individual tasks (component grids)
     for (size_t i = 0; i < levels.size(); i++) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
@@ -2,6 +2,7 @@
 #define SRC_SGPP_COMBIGRID_COMBISCHEME_COMBIMINMAXSCHEME_HPP_
 
 #include <boost/math/special_functions/binomial.hpp>
+#include <boost/property_tree/json_parser.hpp>
 #include <numeric>
 #include "sgpp/distributedcombigrid/utils/LevelVector.hpp"
 #include "sgpp/distributedcombigrid/utils/Types.hpp"
@@ -35,7 +36,7 @@ class CombiMinMaxScheme {
       if (i == 0) effDim_--;
   }
 
-  ~CombiMinMaxScheme(){};
+  virtual ~CombiMinMaxScheme() = default;
 
   /* Generate the combischeme corresponding to the classical combination technique.
    * We need to ensure that lmax = lmin +c*ones(dim), and take special care
@@ -59,7 +60,7 @@ class CombiMinMaxScheme {
 
   inline void print(std::ostream& os) const;
 
- private:
+ protected:
   /* L1 norm of combispaces on the highest diagonal */
   LevelType n_;
 
@@ -109,5 +110,46 @@ inline void CombiMinMaxScheme::print(std::ostream& os) const {
 
   os << std::endl;
 }
-}
+
+class CombiMinMaxSchemeFromFile : public CombiMinMaxScheme {
+ public:
+  CombiMinMaxSchemeFromFile(DimType dim, LevelVector& lmin, LevelVector& lmax, std::string ctschemeFile)
+      : CombiMinMaxScheme(dim, lmin, lmax) {
+    // read in CT scheme, if applicable
+    boost::property_tree::ptree pScheme;
+    boost::property_tree::json_parser::read_json(ctschemeFile, pScheme);
+    for (const auto& component : pScheme.get_child("")) {
+      assert(component.first.empty());  // list elements have no names
+      for (const auto& c : component.second) {
+        if (c.first == "coeff") {
+          coefficients_.push_back(c.second.get_value<real>());
+        } else if (c.first == "level") {
+          LevelVector lvl(dim);
+          int i = 0;
+          for (const auto& l : c.second) {
+            lvl[i] = l.second.get_value<int>();
+            ++i;
+          }
+          assert(lvl <= lmax);
+          assert(lmin <= lvl);
+          combiSpaces_.push_back(lvl);
+        } else if (c.first == "group_no") {
+          processGroupNumbers_.push_back(c.second.get_value<size_t>());
+        } else {
+          assert(false);
+        }
+      }
+      // process group numbers should either be always given or never
+      assert(coefficients_.size() == combiSpaces_.size());
+      assert(coefficients_.size() == combiSpaces_.size());
+    }
+    assert(coefficients_.size() > 0);
+    assert(coefficients_.size() == combiSpaces_.size());
+  }
+
+  inline const std::vector<size_t>& getProcessGroupNumbers() const { return processGroupNumbers_; }
+ private:
+  std::vector<size_t> processGroupNumbers_;
+};
+}  // namespace combigrid
 #endif /* SRC_SGPP_COMBIGRID_COMBISCHEME_COMBIMINMAXSCHEME_HPP_ */

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -1978,7 +1978,7 @@ class DistributedFullGrid {
     {
       partitionCoords_.resize(this->getCommunicatorSize());
       // fill partition coords vector, only once
-      for (size_t i = 0; i < this->getCommunicatorSize(); ++i) {
+      for (int i = 0; i < this->getCommunicatorSize(); ++i) {
         std::vector<int> tmp(dim_);
         MPI_Cart_coords(communicator_, i, static_cast<int>(dim_), &tmp[0]);
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/loadmodel/LearningLoadModel.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/loadmodel/LearningLoadModel.hpp
@@ -12,7 +12,7 @@ namespace combigrid {
  * This POD only contains fields that change over the runtime of a simulation.
  */
 struct DurationInformation {
-  int task_id; /**< included for easy identification of the corresponding task */
+  size_t task_id; /**< included for easy identification of the corresponding task */
   unsigned long duration;
   real simtime_now;
   real real_dt;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
@@ -14,7 +14,7 @@ class CombiParameters {
 
   CombiParameters(DimType dim, LevelVector lmin, LevelVector lmax, std::vector<bool>& boundary,
                   std::vector<LevelVector>& levels, std::vector<real>& coeffs,
-                  std::vector<int>& taskIDs, IndexType numberOfCombinations, IndexType numGrids = 1,
+                  std::vector<size_t>& taskIDs, IndexType numberOfCombinations, IndexType numGrids = 1,
                   LevelVector reduceCombinationDimsLmin = std::vector<IndexType>(0),
                   LevelVector reduceCombinationDimsLmax = std::vector<IndexType>(0),
                   bool forwardDecomposition = !isGENE)
@@ -35,7 +35,7 @@ class CombiParameters {
 
   CombiParameters(DimType dim, LevelVector lmin, LevelVector lmax, std::vector<bool>& boundary,
                   std::vector<LevelVector>& levels, std::vector<real>& coeffs,
-                  std::vector<bool>& hierachizationDims, std::vector<int>& taskIDs,
+                  std::vector<bool>& hierachizationDims, std::vector<size_t>& taskIDs,
                   IndexType numberOfCombinations, IndexType numGrids = 1,
                   LevelVector reduceCombinationDimsLmin = std::vector<IndexType>(0),
                   LevelVector reduceCombinationDimsLmax = std::vector<IndexType>(0),
@@ -67,25 +67,25 @@ class CombiParameters {
 
   inline const std::vector<bool>& getBoundary() { return boundary_; }
 
-  inline real getCoeff(int taskID) { return coeffs_[taskID]; }
+  inline real getCoeff(size_t taskID) { return coeffs_[taskID]; }
 
-  inline void getCoeffs(std::vector<int>& taskIDs, std::vector<real>& coeffs) {
+  inline void getCoeffs(std::vector<size_t>& taskIDs, std::vector<real>& coeffs) {
     for (auto it : coeffs_) {
       taskIDs.push_back(it.first);
       coeffs.push_back(it.second);
     }
   }
 
-  inline std::map<int, real>& getCoeffsDict() { return coeffs_; }
+  inline std::map<size_t, real>& getCoeffsDict() { return coeffs_; }
 
-  inline std::map<LevelVector, int>& getLevelsToIDs() { return levelsToIDs_; }
+  inline std::map<LevelVector, size_t>& getLevelsToIDs() { return levelsToIDs_; }
 
-  inline void setCoeff(int taskID, real coeff) {
+  inline void setCoeff(size_t taskID, real coeff) {
     coeffs_[taskID] = coeff;
     combiDictionary_[levels_[taskID]] = coeff;
   }
 
-  inline void setLevelsCoeffs(std::vector<int>& taskIDs, std::vector<LevelVector>& levels,
+  inline void setLevelsCoeffs(std::vector<size_t>& taskIDs, std::vector<LevelVector>& levels,
                               std::vector<real>& coeffs) {
     assert(taskIDs.size() == coeffs.size());
     assert(taskIDs.size() == levels.size());
@@ -98,18 +98,18 @@ class CombiParameters {
     }
   }
 
-  inline const LevelVector& getLevel(int taskID) { return levels_[taskID]; }
+  inline const LevelVector& getLevel(size_t taskID) { return levels_[taskID]; }
 
-  inline int getID(LevelVector level) { return getLevelsToIDs()[level]; }
+  inline size_t getID(LevelVector level) { return getLevelsToIDs()[level]; }
 
-  inline void getLevels(std::vector<int>& taskIDs, std::vector<LevelVector>& levels) {
+  inline void getLevels(std::vector<size_t>& taskIDs, std::vector<LevelVector>& levels) {
     for (auto it : levels_) {
       taskIDs.push_back(it.first);
       levels.push_back(it.second);
     }
   }
 
-  inline std::map<int, LevelVector>& getLevelsDict() { return levels_; }
+  inline std::map<size_t, LevelVector>& getLevelsDict() { return levels_; }
 
   inline std::map<LevelVector, real>& getCombiDict() { return combiDictionary_; }
 
@@ -169,11 +169,11 @@ class CombiParameters {
 
   std::vector<bool> boundary_;
 
-  std::map<int, LevelVector> levels_;
+  std::map<size_t, LevelVector> levels_;
 
-  std::map<int, real> coeffs_;
+  std::map<size_t, real> coeffs_;
 
-  std::map<LevelVector, int> levelsToIDs_;
+  std::map<LevelVector, size_t> levelsToIDs_;
 
   std::map<LevelVector, real> combiDictionary_;
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/CombiParameters.hpp
@@ -153,6 +153,28 @@ class CombiParameters {
     return procsSet_;
   }
 
+  /**
+   * @brief Set the Decomposition
+   *
+   * @param decomposition a vector of index vectors, specifying for each dimension
+   *        the lowest 1d index (on a full grid of level lmax)
+   *        that will belong to each cartesian communicator slice
+   */
+  inline void setDecomposition(const std::vector<IndexVector>& decomposition) {
+    assert(uniformDecomposition);
+    decomposition_ = decomposition;
+    for (DimType d = 0; d < dim_; ++d) {
+      assert(decomposition[d][0] == 0);
+      auto numPoints = powerOfTwo[lmax_[d]] + (boundary_[d] ? 1 : -1);
+      assert(decomposition[d].back() < numPoints);
+      assert(procs_[d] == decomposition[d].size());
+    }
+  }
+
+  inline const std::vector<IndexVector>& getDecomposition() const {
+    return decomposition_;
+  }
+
   inline bool getForwardDecomposition() const {
     if (isGENE){
       assert(!forwardDecomposition_);
@@ -182,6 +204,8 @@ class CombiParameters {
   IndexVector procs_;
 
   bool procsSet_;
+
+  std::vector<IndexVector> decomposition_;
 
   bool forwardDecomposition_;
 
@@ -226,6 +250,7 @@ void CombiParameters::serialize(Archive& ar, const unsigned int version) {
   ar& hierarchizationDims_;
   ar& procs_;
   ar& procsSet_;
+  ar& decomposition_;
   ar& forwardDecomposition_;
   ar& numberOfCombinations_;
   ar& numGridsPerTask_;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.cpp
@@ -210,7 +210,7 @@ std::vector<double> ProcessGroupManager::parallelEvalNorm(const LevelVector& lev
   return norms;
 }
 
-void ProcessGroupManager::getLpNorms(int p, std::map<int, double>& norms) {
+void ProcessGroupManager::getLpNorms(int p, std::map<size_t, double>& norms) {
   SignalType signal;
   if (p == 2) {
     signal = GET_L2_NORM;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.hpp
@@ -73,7 +73,7 @@ class ProcessGroupManager {
 
   bool parallelEval(const LevelVector& leval, std::string& filename);
 
-  void getLpNorms(int p, std::map<int, double>& norms);
+  void getLpNorms(int p, std::map<size_t, double>& norms);
 
   std::vector<double> parallelEvalNorm(const LevelVector& leval);
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.hpp
@@ -126,7 +126,9 @@ class ProcessGroupWorker {
 
   // std::ofstream betasFile_;
 
-  void initializeTaskAndFaults(bool mayAlreadyExist = true);
+  void initializeTaskAndFaults(Task* t);
+
+  void receiveAndInitializeTaskAndFaults(bool mayAlreadyExist = true);
 
   /** sets all subspaces in all dsgs to zero and allocates them if necessary */
   void zeroDsgsData();

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
@@ -141,7 +141,7 @@ void ProcessManager::updateCombiParameters() {
 /*
  * Compute the group faults that occured at this combination step using the fault simulator
  */
-void ProcessManager::getGroupFaultIDs(std::vector<int>& faultsID,
+void ProcessManager::getGroupFaultIDs(std::vector<size_t>& faultsID,
                                       std::vector<ProcessGroupManagerID>& groupFaults) {
   for (auto p : pgroups_) {
     StatusType status = p->waitStatus();
@@ -154,7 +154,7 @@ void ProcessManager::getGroupFaultIDs(std::vector<int>& faultsID,
   }
 }
 
-void ProcessManager::redistribute(std::vector<int>& taskID) {
+void ProcessManager::redistribute(std::vector<size_t>& taskID) {
   for (size_t i = 0; i < taskID.size(); ++i) {
     // find id in list of tasks
     Task* t = NULL;
@@ -189,7 +189,7 @@ void ProcessManager::redistribute(std::vector<int>& taskID) {
 }
 
 void ProcessManager::reInitializeGroup(std::vector<ProcessGroupManagerID>& recoveredGroups,
-                                       std::vector<int>& tasksToIgnore) {
+                                       std::vector<size_t>& tasksToIgnore) {
   std::vector<Task*> removeTasks;
   for (auto g : recoveredGroups) {
     // erase existing tasks in group members to avoid doubled tasks
@@ -228,7 +228,7 @@ void ProcessManager::reInitializeGroup(std::vector<ProcessGroupManagerID>& recov
   std::cout << "Reinitialization finished" << std::endl;
 }
 
-void ProcessManager::recompute(std::vector<int>& taskID, bool failedRecovery,
+void ProcessManager::recompute(std::vector<size_t>& taskID, bool failedRecovery,
                                std::vector<ProcessGroupManagerID>& recoveredGroups) {
   for (size_t i = 0; i < taskID.size(); ++i) {
     // find id in list of tasks
@@ -309,13 +309,14 @@ bool ProcessManager::recoverCommunicators(std::vector<ProcessGroupManagerID> fai
 
 void ProcessManager::recover(int i, int nsteps) {  // outdated
 
-  std::vector<int> faultsID;
+  assert(false && "deprecated function recover");
+  std::vector<size_t> faultsID;
   std::vector<ProcessGroupManagerID> groupFaults;
   getGroupFaultIDs(faultsID, groupFaults);
 
   /* call optimization code to find new coefficients */
   const std::string prob_name = "interpolation based optimization";
-  std::vector<int> redistributeFaultsID, recomputeFaultsID;
+  std::vector<size_t> redistributeFaultsID, recomputeFaultsID;
   recomputeOptimumCoefficients(prob_name, faultsID, redistributeFaultsID, recomputeFaultsID);
   // time does not need to be updated in gene but maybe in other applications
   /*  for ( auto id : redistributeFaultsID ) {
@@ -397,8 +398,8 @@ void ProcessManager::parallelEval(const LevelVector& leval, std::string& filenam
   }
 }
 
-std::map<int, double> ProcessManager::getLpNorms(int p) {
-  std::map<int, double> norms;
+std::map<size_t, double> ProcessManager::getLpNorms(int p) {
+  std::map<size_t, double> norms;
 
   for (const auto& pg : pgroups_) {
     pg->getLpNorms(p, norms);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.hpp
@@ -69,25 +69,25 @@ class ProcessManager {
   inline void gridEval(FullGrid<FG_ELEMENT>& fg);
 
   /* Generates no_faults random faults from the combischeme */
-  inline void createRandomFaults(std::vector<int>& faultIds, int no_faults);
+  inline void createRandomFaults(std::vector<size_t>& faultIds, int no_faults);
 
-  inline void recomputeOptimumCoefficients(std::string prob_name, std::vector<int>& faultsID,
-                                           std::vector<int>& redistributefaultsID,
-                                           std::vector<int>& recomputeFaultsID);
+  inline void recomputeOptimumCoefficients(std::string prob_name, std::vector<size_t>& faultsID,
+                                           std::vector<size_t>& redistributefaultsID,
+                                           std::vector<size_t>& recomputeFaultsID);
 
-  inline Task* getTask(int taskID);
+  inline Task* getTask(size_t taskID);
 
   void updateCombiParameters();
 
   /* Computes group faults in current combi scheme step */
-  void getGroupFaultIDs(std::vector<int>& faultsID,
+  void getGroupFaultIDs(std::vector<size_t>& faultsID,
                         std::vector<ProcessGroupManagerID>& groupFaults);
 
   inline CombiParameters& getCombiParameters();
 
   void parallelEval(const LevelVector& leval, std::string& filename, size_t groupID);
 
-  std::map<int, double> getLpNorms(int p = 2);
+  std::map<size_t, double> getLpNorms(int p = 2);
 
   std::vector<double> parallelEvalNorm(const LevelVector& leval, size_t groupID = 0);
 
@@ -97,12 +97,12 @@ class ProcessManager {
 
   std::vector<CombiDataType> interpolateValues(const std::vector<std::vector<real>>& interpolationCoords);
 
-  void redistribute(std::vector<int>& taskID);
+  void redistribute(std::vector<size_t>& taskID);
 
   void reInitializeGroup(std::vector<ProcessGroupManagerID>& taskID,
-                         std::vector<int>& tasksToIgnore);
+                         std::vector<size_t>& tasksToIgnore);
 
-  void recompute(std::vector<int>& taskID, bool failedRecovery,
+  void recompute(std::vector<size_t>& taskID, bool failedRecovery,
                  std::vector<ProcessGroupManagerID>& recoveredGroups);
 
   void recover(int i, int nsteps);
@@ -297,8 +297,8 @@ CombiParameters& ProcessManager::getCombiParameters() { return params_; }
  * simply cannot give the evaluation results, but they are still available in the MPI
  * communication scheme (the nodes are not dead)
  */
-inline void ProcessManager::createRandomFaults(std::vector<int>& faultIds, int no_faults) {
-  int fault_id;
+inline void ProcessManager::createRandomFaults(std::vector<size_t>& faultIds, int no_faults) {
+  size_t fault_id;
 
   // create random faults
   int j = 0;
@@ -316,12 +316,12 @@ inline void ProcessManager::createRandomFaults(std::vector<int>& faultIds, int n
  * an optimization scheme
  */
 inline void ProcessManager::recomputeOptimumCoefficients(std::string prob_name,
-                                                         std::vector<int>& faultsID,
-                                                         std::vector<int>& redistributeFaultsID,
-                                                         std::vector<int>& recomputeFaultsID) {
+                                                         std::vector<size_t>& faultsID,
+                                                         std::vector<size_t>& redistributeFaultsID,
+                                                         std::vector<size_t>& recomputeFaultsID) {
   CombigridDict given_dict = params_.getCombiDict();
 
-  std::map<int, LevelVector> IDsToLevels = params_.getLevelsDict();
+  std::map<size_t, LevelVector> IDsToLevels = params_.getLevelsDict();
   LevelVectorList faultLevelVectors;
   for (auto id : faultsID) faultLevelVectors.push_back(IDsToLevels[id]);
 
@@ -340,7 +340,7 @@ inline void ProcessManager::recomputeOptimumCoefficients(std::string prob_name,
 
     LevelVectorList newLevels;
     std::vector<real> newCoeffs;
-    std::vector<int> newTaskIDs;
+    std::vector<size_t> newTaskIDs;
 
     int numLevels = int(params_.getNumLevels());
     for (int i = 0; i < numLevels; ++i) {
@@ -364,7 +364,7 @@ inline void ProcessManager::recomputeOptimumCoefficients(std::string prob_name,
     assert(roundedSum == 1);
     params_.setLevelsCoeffs(newTaskIDs, newLevels, newCoeffs);
 
-    std::map<LevelVector, int> LevelsToIDs = params_.getLevelsToIDs();
+    std::map<LevelVector, size_t> LevelsToIDs = params_.getLevelsToIDs();
     for (auto l : recomputeLevelVectors) {
       recomputeFaultsID.push_back(LevelsToIDs[l]);
     }
@@ -378,7 +378,7 @@ inline void ProcessManager::recomputeOptimumCoefficients(std::string prob_name,
   }
 }
 
-inline Task* ProcessManager::getTask(int taskID) {
+inline Task* ProcessManager::getTask(size_t taskID) {
   for (Task* tmp : tasks_) {
     if (tmp->getID() == taskID) {
       return tmp;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/task/Task.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/task/Task.cpp
@@ -25,7 +25,7 @@ Task::~Task() {
   delete faultCriterion_;
 }
 
-int Task::count = 0;
+size_t Task::count = 0;
 
 void Task::send(Task** t, RankType dst, CommunicatorType comm) {
   // save data to archive

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/task/Task.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/task/Task.hpp
@@ -54,7 +54,7 @@ class Task {
 
   inline const std::vector<bool>& getBoundary() const;
 
-  inline int getID() const;
+  inline size_t getID() const;
 
   virtual void run(CommunicatorType lcomm) = 0;
 
@@ -114,9 +114,9 @@ class Task {
 
   std::vector<bool> boundary_;
 
-  int id_;  // unique id of task, same on manager and worker
+  size_t id_;  // unique id of task, same on manager and worker
 
-  static int count;
+  static size_t count;
 
   LoadModel* loadModel_;
 
@@ -125,7 +125,7 @@ class Task {
 
 typedef std::vector<Task*> TaskContainer;
 
-inline const LevelVector& getLevelVectorFromTaskID(TaskContainer tasks, int task_id){
+inline const LevelVector& getLevelVectorFromTaskID(TaskContainer tasks, size_t task_id){
   auto task = std::find_if(tasks.begin(), tasks.end(), 
     [task_id] (Task* t) {return t->getID() == task_id;}
   );
@@ -149,7 +149,7 @@ inline const LevelVector& Task::getLevelVector() const { return l_; }
 
 inline const std::vector<bool>& Task::getBoundary() const { return boundary_; }
 
-inline int Task::getID() const { return id_; }
+inline size_t Task::getID() const { return id_; }
 
 inline bool Task::isFinished() const { return isFinished_; }
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/task/Task.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/task/Task.hpp
@@ -56,6 +56,15 @@ class Task {
 
   inline size_t getID() const;
 
+  /**
+   * @brief explicitly set a new ID for the task;
+   * may be useful if process groups read their task assignment from file instead of receiving it
+   * from the manager
+   *
+   * make sure ID is continuous and unique!
+   */
+  inline void setID(size_t ID);
+
   virtual void run(CommunicatorType lcomm) = 0;
 
   virtual void changeDir(CommunicatorType lcomm) {
@@ -150,6 +159,8 @@ inline const LevelVector& Task::getLevelVector() const { return l_; }
 inline const std::vector<bool>& Task::getBoundary() const { return boundary_; }
 
 inline size_t Task::getID() const { return id_; }
+
+inline void Task::setID(size_t id) { id_ = id; }
 
 inline bool Task::isFinished() const { return isFinished_; }
 

--- a/distributedcombigrid/tests/TaskCount.hpp
+++ b/distributedcombigrid/tests/TaskCount.hpp
@@ -36,8 +36,15 @@ class TaskCount : public combigrid::Task {
   void init(CommunicatorType lcomm, std::vector<IndexVector> decomposition) {
 
     long nprocs = getCommSize(lcomm);
-    IndexVector p = {nprocs,1};
-    dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(), p);
+    IndexVector p;
+    if (decomposition.size() == 0) {
+      p = {nprocs,1};
+    } else {
+      for (const auto& d : decomposition) {
+        p.push_back(d.size());
+      }
+    }
+    dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(), p, true, decomposition);
 
     std::vector<CombiDataType>& elements = dfg_->getElementVector();
     for (auto& element : elements) {

--- a/distributedcombigrid/tests/TaskCount.hpp
+++ b/distributedcombigrid/tests/TaskCount.hpp
@@ -31,7 +31,9 @@ class TestFnCount {
 class TaskCount : public combigrid::Task {
  public:
   TaskCount(DimType dim, LevelVector& l, std::vector<bool>& boundary, real coeff, LoadModel* loadModel)
-      : Task(dim, l, boundary, coeff, loadModel){}
+      : Task(dim, l, boundary, coeff, loadModel), dfg_(nullptr){
+        BOOST_TEST_CHECKPOINT("TaskCount constructor");
+      }
 
   void init(CommunicatorType lcomm, std::vector<IndexVector> decomposition) {
 
@@ -50,7 +52,7 @@ class TaskCount : public combigrid::Task {
     for (auto& element : elements) {
       element = -0.;
     }
-    BOOST_CHECK(true);
+    BOOST_TEST_CHECKPOINT("TaskCount init");
   }
 
   void run(CommunicatorType lcomm) {
@@ -70,20 +72,24 @@ class TaskCount : public combigrid::Task {
     setFinished(true);
 
     MPI_Barrier(lcomm);
-    BOOST_CHECK(true);
+    BOOST_TEST_CHECKPOINT("TaskCount run");
   }
 
   void getFullGrid(FullGrid<CombiDataType>& fg, RankType r, CommunicatorType lcomm, int n = 0) {
-    BOOST_CHECK(true);
+    BOOST_TEST_CHECKPOINT("TaskCount getFullGrid");
     dfg_->gatherFullGrid(fg, r);
   }
 
   DistributedFullGrid<CombiDataType>& getDistributedFullGrid(int n = 0) { return *dfg_; }
 
-  void setZero() { BOOST_CHECK(true); }
+  void setZero() {
+    BOOST_TEST_CHECKPOINT("TaskCount setZero");
+  }
 
   ~TaskCount() {
+    BOOST_TEST_CHECKPOINT("TaskCount destructor begin");
     if (dfg_ != NULL) delete dfg_;
+    BOOST_TEST_CHECKPOINT("TaskCount destructor");
   }
 
  protected:

--- a/distributedcombigrid/tests/test_ftolerance.cpp
+++ b/distributedcombigrid/tests/test_ftolerance.cpp
@@ -264,7 +264,7 @@ void checkFtolerance(bool useCombine, bool useFG, double l0err, double l2err, si
 
     /* create Tasks */
    TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
 
     #ifdef ENABLEFT
       for (size_t i = 0; i < levels.size(); i++) {

--- a/distributedcombigrid/tests/test_integration.cpp
+++ b/distributedcombigrid/tests/test_integration.cpp
@@ -114,7 +114,7 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
 
     // create Tasks
     TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
     for (size_t i = 0; i < levels.size(); i++) {
       Task* t = new TaskCount(dim, levels[i], boundary, coeffs[i], loadmodel.get());
       tasks.push_back(t);

--- a/distributedcombigrid/tests/test_mpisystem.cpp
+++ b/distributedcombigrid/tests/test_mpisystem.cpp
@@ -63,7 +63,7 @@ void checkMPIRanksAndCommunication(size_t ngroup, size_t nprocs) {
 
   //   // create Tasks
   //   TaskContainer tasks;
-  //   std::vector<int> taskIDs;
+  //   std::vector<size_t> taskIDs;
   //   for (size_t i = 0; i < levels.size(); i++) {
   //     Task* t = new TaskCount(dim, levels[i], boundary, coeffs[i], loadmodel.get());
   //     tasks.push_back(t);

--- a/distributedcombigrid/tests/test_reduce.cpp
+++ b/distributedcombigrid/tests/test_reduce.cpp
@@ -158,7 +158,7 @@ void checkCombine(size_t ngroup = 1, size_t nprocs = 1) {
 
     // create Tasks
     TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
     for (size_t i = 0; i < levels.size(); i++) {
       Task* t = new TaskConst(levels[i], boundary, coeffs[i], loadmodel.get());
       tasks.push_back(t);

--- a/distributedcombigrid/tests/test_rescheduling.cpp
+++ b/distributedcombigrid/tests/test_rescheduling.cpp
@@ -191,7 +191,7 @@ void checkRescheduling(size_t ngroup = 1, size_t nprocs = 1) {
 
     // create Tasks
     TaskContainer tasks;
-    std::vector<int> taskIDs;
+    std::vector<size_t> taskIDs;
     for (size_t i = 0; i < levels.size(); i++) {
       Task* t = new TestingTask(levels[i], boundary, coeffs[i], loadmodel.get());
       tasks.push_back(t);

--- a/distributedcombigrid/tests/test_scheme.json
+++ b/distributedcombigrid/tests/test_scheme.json
@@ -1,0 +1,11 @@
+[
+    {"coeff": 1.0, "level": [7, 6], "group_no": 1},
+    {"coeff": 1.0, "level": [6, 7], "group_no": 1},
+    {"coeff": 1.0, "level": [5, 8], "group_no": 0},
+    {"coeff": 1.0, "level": [4, 9], "group_no": 3},
+    {"coeff": 1.0, "level": [3, 10], "group_no": 2},
+    {"coeff": -1.0, "level": [6, 6], "group_no": 4},
+    {"coeff": -1.0, "level": [5, 7], "group_no": 4},
+    {"coeff": -1.0, "level": [4, 8], "group_no": 6},
+    {"coeff": -1.0, "level": [3, 9], "group_no": 7}
+]

--- a/distributedcombigrid/tools/generate_combischeme_json.py
+++ b/distributedcombigrid/tools/generate_combischeme_json.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+from tokenize import group
+import numpy as np
+import itertools as it
+from icecream import ic
+from scipy.special import binom
+import json
+
+
+class ClassicDiagonalActiveSet():
+    def __init__(self, lmax, lmin=None, diagonalIndex=0):
+        self.lmax = lmax
+        if lmin == None:
+            self.lmin = [1 for i in range(len(self.lmax))]
+        else:
+            self.lmin = lmin
+        self.diagonalIndex = diagonalIndex
+
+    def getMinLevelSum(self):
+        return self.getLevelMinima().sum()
+
+    def getLevelMinima(self):
+        maxInd = np.argmax(np.array(self.lmax)-np.array(self.lmin))
+        lm = np.array(self.lmin)
+        lm[maxInd] = self.lmax[maxInd]
+        return lm
+
+    def getActiveSet(self):
+        listOfRanges = [list(range(0, self.lmax[i]+1))
+                        for i in range(len(self.lmax))]
+        listOfAllGrids = list(it.product(*listOfRanges))
+        s = set()
+        levelSum = self.getMinLevelSum()+self.diagonalIndex
+        for grid in listOfAllGrids:
+            if (np.sum(grid) == levelSum and (np.array(grid) >= np.array(self.lmin)).all()):
+                s.add(grid)
+
+        return s
+
+
+class combinationSchemeArbitrary():
+    def __init__(self, activeSet):
+        self.activeSet = activeSet
+        self.updateDict()
+
+    def getDownSet(self, l):
+        subs = [list(range(0, x + 1)) for x in l]
+        downSet = it.product(*subs)
+        return downSet
+
+    def getSubspaces(self):
+        subspacesSet = set()
+        for l in self.dictOfScheme:
+            for subspace in self.getDownSet(l):
+                subspacesSet.add(subspace)
+        return subspacesSet
+
+    def updateDict(self):
+        lmin = self.activeSet.lmin
+        lmax = self.activeSet.lmax
+        firstLevelDifference = lmax[0] - lmin[0]
+        dim = len(lmin)
+        uniformLevelDifference = [(lmax[i] - lmin[i]) == firstLevelDifference for i in range(dim)]
+        if uniformLevelDifference and firstLevelDifference >= dim:
+            ic("binomial")
+            # can calculate it by binomial formula
+            listOfRanges = [list(range(lmin[i], lmax[i]+1))
+                            for i in range(len(lmax))]
+            self.dictOfScheme = {}
+            for q in range(dim):
+                coeff = (-1)**q * binom(dim-1, q)
+                levelSum = sum(lmin) + firstLevelDifference - q
+                # ic(coeff, levelSum)
+                for grid in it.product(*listOfRanges):
+                    if (np.sum(grid) == levelSum and (np.array(grid) >= np.array(lmin)).all()):
+                        self.dictOfScheme[grid] = coeff
+
+        else:
+            self.dictOfScheme = {}
+            for l in self.activeSet.getActiveSet():
+                self.dictOfScheme[l] = 1
+
+            dictOfSubspaces = {}
+
+            for l in self.dictOfScheme:
+                for subspace in self.getDownSet(l):
+                    if subspace in dictOfSubspaces:
+                        dictOfSubspaces[subspace] += 1
+                    else:
+                        dictOfSubspaces[subspace] = 1
+
+            # # remove subspaces which are too much
+            while(set(dictOfSubspaces.values()) != set([1])):
+
+                for subspace in dictOfSubspaces:
+                    currentCount = dictOfSubspaces[subspace]
+                    if currentCount != 1:
+                        diff = currentCount - 1
+
+                        if subspace in self.dictOfScheme:
+
+                            self.dictOfScheme[subspace] -= diff
+                            if self.dictOfScheme[subspace] == 0:
+                                del self.dictOfScheme[subspace]
+
+                        else:
+                            self.dictOfScheme[subspace] = -diff
+
+                        for l in self.getDownSet(subspace):
+                            dictOfSubspaces[l] -= diff
+
+    def getCombinationDictionary(self):
+        return self.dictOfScheme
+
+
+lmin = [2]*6
+lmax = [3]*6
+activeSet = ClassicDiagonalActiveSet(lmax, lmin)
+# scheme = active set und Koeffizienten dazu
+scheme = combinationSchemeArbitrary(activeSet)
+
+numGridsOfSize = {}
+
+totalNumPointsCombi = 0
+for key, value in scheme.getCombinationDictionary().items():
+    totalNumPointsCombi += np.prod([2**l + 1 for l in key])
+    levelSum=np.sum([l for l in key])
+    if levelSum in numGridsOfSize:
+        numGridsOfSize[levelSum] += 1
+    else:
+        numGridsOfSize[levelSum] = 1
+
+numGrids = len(scheme.getCombinationDictionary())
+ic(numGrids)
+ic(numGridsOfSize)
+ic(totalNumPointsCombi, totalNumPointsCombi/1e13)
+print(totalNumPointsCombi)
+mem = (totalNumPointsCombi*8) # minimum memory requirement of full grids in scheme in bytes
+mem = mem/(2**20) # memory requirement in Mebibytes
+
+totalNumPointsSparse = 0
+# use optimized sparse grid, with lmax 1 lower in each dim
+reduced_lmax = [max(lmax[d] - 1, lmin[d]) for d in range(len(lmax))]
+# reduced_lmax = [9, 5, 8,8,7]
+activeSetSparse = ClassicDiagonalActiveSet(reduced_lmax, lmin)
+schemeSparse = combinationSchemeArbitrary(activeSetSparse)
+for key in schemeSparse.getSubspaces():
+    # ic(key)
+    totalNumPointsSparse += np.prod([2**(l-1) if l > 0 else 2 for l in key])
+print(totalNumPointsSparse)
+mem_sg = (totalNumPointsSparse*8)
+mem_sg = mem_sg/(2**20) # memory requirement of sparse grid in Mebibytes
+
+mem_total = mem_sg+mem
+ic(mem_total, mem_sg/mem_total)
+
+numProcessGroups = 3
+assignment = { i : {} for i in range(numProcessGroups)}
+roundRobinIndex = 0
+for size in numGridsOfSize:
+    # ic(size)
+    for key, value in scheme.getCombinationDictionary().items():
+        levelSum=np.sum([l for l in key])
+        if levelSum == size:
+            # ic(key, value)
+            assignment[roundRobinIndex][key] = value
+            roundRobinIndex = (roundRobinIndex+1)%numProcessGroups
+
+schemeList = []
+for group_no in assignment.keys():
+    # ic(assignment[group_no])
+    schemeList += [{"coeff": coeff, "level": list(level), "group_no": group_no}
+              for level, coeff in assignment[group_no].items()]
+
+# ic(schemeList)
+jsonString = json.dumps(schemeList)
+
+with open('scheme.json', 'w') as f:
+    f.write(jsonString)

--- a/test_scheme.json
+++ b/test_scheme.json
@@ -1,0 +1,1 @@
+distributedcombigrid/tests/test_scheme.json


### PR DESCRIPTION
DisCoTec should be ready for some absurdly large widely distributed runs, so I put a few features to be merged into master:

- pass in custom decompositions (the default decomposition works only for power-of-two process counts `p`)
- have `Task`'s ID be `size_t`s -- in case we want some reaaaally large task counts
- have some functionality to read combination schemes from json files (plus which process group tasks should be run on, so we can have a static task assignment)
- some script to generate such json scheme files (still missing)