### PR TITLE
Feature interpolation output

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -156,6 +156,7 @@ vars.Add(BoolVariable("OMITREADYSIGNAL","Set to true to avoid that the ready sig
 vars.Add(BoolVariable("UNIFORMDECOMPOSITION","To enable the uniform operations set this to true",True))
 vars.Add(BoolVariable("ENABLEFT","Switch on fault tolerance functionality",True))
 vars.Add(BoolVariable("ISGENE","",False)) #Turn this on for the GENE examples
+vars.Add(BoolVariable("USE_HDF5", "Set if HDF5/HighFive should be used (for interpolation output)", False))
 
 
 # create temporary environment to check which system and compiler we should use

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.cpp
@@ -298,6 +298,18 @@ void ProcessGroupManager::interpolateValues(const std::vector<real>& interpolati
   setProcessGroupBusyAndReceive();
 }
 
+void ProcessGroupManager::writeInterpolatedValues(const std::vector<real>& interpolationCoordsSerial) {
+  sendSignalToProcessGroup(WRITE_INTERPOLATED_VALUES_PER_GRID);
+  MPI_Request dummyRequest;
+  assert(interpolationCoordsSerial.size() < static_cast<size_t>(std::numeric_limits<int>::max()) &&
+         "needs chunking!");
+  MPI_Isend(interpolationCoordsSerial.data(), static_cast<int>(interpolationCoordsSerial.size()),
+            abstraction::getMPIDatatype(abstraction::getabstractionDataType<real>()), pgroupRootID_,
+            TRANSFER_INTERPOLATION_TAG, theMPISystem()->getGlobalComm(), &dummyRequest);
+  MPI_Request_free(&dummyRequest);
+  setProcessGroupBusyAndReceive();
+}
+
 void ProcessGroupManager::recvStatus() {
   // start non-blocking call to receive status
   if (ENABLE_FT) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupManager.hpp
@@ -89,6 +89,8 @@ class ProcessGroupManager {
                                               std::vector<CombiDataType>& values,
                                               MPI_Request& request);
 
+  void writeInterpolatedValues(const std::vector<real>& interpolationCoordsSerial);
+
   /**
    * Adds a task to the process group. To be used for rescheduling.
    *

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupSignals.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupSignals.hpp
@@ -59,6 +59,7 @@ const SignalType EVAL_ERROR_NORM = 35;
 const SignalType INTERPOLATE_VALUES = 36;
 const SignalType DO_DIAGNOSTICS = 37;
 const SignalType WRITE_DSG_MINMAX_COEFFICIENTS = 38;
+const SignalType WRITE_INTERPOLATED_VALUES_PER_GRID = 39;
 
 typedef int NormalizationType;
 const NormalizationType NO_NORMALIZATION = 0;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
@@ -17,6 +17,10 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
+#ifdef HAVE_HIGHFIVE
+// highfive is a C++ hdf5 wrapper, available in spack (-> configure with right boost and mpi versions)
+#include <highfive/H5File.hpp>
+#endif
 #include "sgpp/distributedcombigrid/mpi_fault_simulator/MPI-FT.h"
 
 namespace combigrid {
@@ -280,6 +284,11 @@ SignalType ProcessGroupWorker::wait() {
           TRANSFER_INTERPOLATION_TAG, theMPISystem()->getGlobalComm());
       }
       Stats::stopEvent("interpolate values");
+    } break;
+    case WRITE_INTERPOLATED_VALUES_PER_GRID: {  // interpolate values on given coordinates and write values to .h5
+      Stats::startEvent("write interpolated values");
+      writeInterpolatedValuesPerGrid();
+      Stats::stopEvent("write interpolated values");
     } break;
     case RESCHEDULE_ADD_TASK: {
       assert(currentTask_ == nullptr);
@@ -868,9 +877,7 @@ void ProcessGroupWorker::doDiagnostics() {
   assert(false && "this taskID is not here");
 }
 
-std::vector<CombiDataType> ProcessGroupWorker::interpolateValues() {
-  assert(combiParameters_.getNumGrids() == 1 && "interpolate only implemented for 1 species!");
-  // receive coordinates and broadcast to group members
+void receiveAndBroadcastInterpolationCoords(std::vector<std::vector<real>>& interpolationCoords, DimType dim) {
   std::vector<real> interpolationCoordsSerial;
   auto realType = abstraction::getMPIDatatype(abstraction::getabstractionDataType<real>());
   int coordsSize;
@@ -891,21 +898,29 @@ std::vector<CombiDataType> ProcessGroupWorker::interpolateValues() {
             theMPISystem()->getMasterRank(), theMPISystem()->getLocalComm());
 
   // split vector into coordinates
-  const int dim = static_cast<int>(combiParameters_.getDim());
-  auto numCoordinates = coordsSize / dim;
-  assert( coordsSize % dim == 0);
-  std::vector<std::vector<real>> interpolationCoords(numCoordinates);
+  const int dimInt = static_cast<int>(dim);
+  auto numCoordinates = coordsSize / dimInt;
+  assert( coordsSize % dimInt == 0);
+  interpolationCoords.resize(numCoordinates);
   auto it = interpolationCoordsSerial.cbegin();
   for (auto& coord: interpolationCoords) {
-    coord.insert(coord.end(), it, it+dim);
-    it += dim;
+    coord.insert(coord.end(), it, it+dimInt);
+    it += dimInt;
   }
   assert(it == interpolationCoordsSerial.end());
+}
+
+std::vector<CombiDataType> ProcessGroupWorker::interpolateValues() {
+  assert(combiParameters_.getNumGrids() == 1 && "interpolate only implemented for 1 species!");
+  // receive coordinates and broadcast to group members
+  std::vector<std::vector<real>> interpolationCoords;
+  receiveAndBroadcastInterpolationCoords(interpolationCoords, combiParameters_.getDim());
+  auto numCoordinates = interpolationCoords.size();
 
   // call interpolation function on tasks and reduce with combination coefficient
   std::vector<CombiDataType> values(numCoordinates, 0.);
   for (Task* t : tasks_){
-    auto coeff = combiParameters_.getCoeff(t->getID());
+    auto coeff = this->combiParameters_.getCoeff(t->getID());
     auto taskVals = t->getDistributedFullGrid().getInterpolatedValues(interpolationCoords);
 
     for (size_t i = 0; i < numCoordinates; ++i) {
@@ -913,6 +928,33 @@ std::vector<CombiDataType> ProcessGroupWorker::interpolateValues() {
     }
   }
   return values;
+}
+
+
+void ProcessGroupWorker::writeInterpolatedValuesPerGrid() {
+#ifdef HAVE_HIGHFIVE
+  assert(combiParameters_.getNumGrids() == 1 && "interpolate only implemented for 1 species!");
+  // receive coordinates and broadcast to group members
+  std::vector<std::vector<real>> interpolationCoords;
+  receiveAndBroadcastInterpolationCoords(interpolationCoords, combiParameters_.getDim());
+  auto numCoordinates = interpolationCoords.size();
+
+  // call interpolation function on tasks and write out task-wise
+  for (size_t i = 0; i < tasks_.size(); ++i){
+    auto taskVals = t->getDistributedFullGrid().getInterpolatedValues(interpolationCoords);
+    if (i%nprocs == rank) {
+      std::string saveFilePath = "interpolated_" + std::to_string(tasks_[i]->getID()) + ".h5";
+      // check if file already exists, if no, create
+      HighFive::File h5_file(saveFilePath, HighFive::File::OpenOrCreate);
+
+      HighFive::DataSet dataset = file.createDataSet<int>("/interpolated_" + std::to_string(currentCombi_),  HighFive::DataSpace::From(taskVals));
+
+      dataset.write(taskVals);
+    }
+  }
+#else // not compiled with hdf5
+  throw std::runtime_error("requesting hdf5 write but built without hdf5 support");
+#endif
 }
 
 void ProcessGroupWorker::gridEval() {  // not supported anymore

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <string>
 #ifdef HAVE_HIGHFIVE
+#include <chrono>
+#include <random>
 // highfive is a C++ hdf5 wrapper, available in spack (-> configure with right boost and mpi versions)
 #include <highfive/H5File.hpp>
 #endif
@@ -940,22 +942,44 @@ void ProcessGroupWorker::writeInterpolatedValuesPerGrid() {
   auto numCoordinates = interpolationCoords.size();
 
   // call interpolation function on tasks and write out task-wise
-  for (size_t i = 0; i < tasks_.size(); ++i){
+  for (size_t i = 0; i < tasks_.size(); ++i) {
     auto taskVals = tasks_[i]->getDistributedFullGrid().getInterpolatedValues(interpolationCoords);
     if (i % (theMPISystem()->getNumProcs()) == theMPISystem()->getLocalRank()) {
+      // generate a rank-local per-run random number
+      // std::random_device dev;
+      static std::mt19937 rng(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+      static std::uniform_int_distribution<std::mt19937::result_type> dist(
+          1, std::numeric_limits<size_t>::max());
+      static size_t rankLocalRandom = dist(rng);
+
       std::string saveFilePath = "interpolated_" + std::to_string(tasks_[i]->getID()) + ".h5";
       // check if file already exists, if no, create
-      HighFive::File h5_file(saveFilePath, HighFive::File::OpenOrCreate);
+      HighFive::File h5_file(saveFilePath,
+                             HighFive::File::OpenOrCreate | HighFive::File::ReadWrite);
 
-      HighFive::DataSet dataset = h5_file.createDataSet<CombiDataType>("/interpolated_" + std::to_string(currentCombi_),  HighFive::DataSpace::From(taskVals));
+      // std::vector<std::string> elems = h5_file.listObjectNames();
+      // std::cout << elems << std::endl;
+
+      std::string groupName = "run_" + std::to_string(rankLocalRandom);
+      HighFive::Group group;
+      if (h5_file.exist(groupName)) {
+        group = h5_file.getGroup(groupName);
+      } else {
+        group = h5_file.createGroup(groupName);
+      }
+
+      std::string datasetName = "interpolated_" + std::to_string(currentCombi_);
+      HighFive::DataSet dataset =
+          group.createDataSet<CombiDataType>(datasetName, HighFive::DataSpace::From(taskVals));
 
       dataset.write(taskVals);
 
-      HighFive::Attribute a2 = dataset.createAttribute<real>("simulation_time",  HighFive::DataSpace::From(tasks_[i]->getCurrentTime()));
+      HighFive::Attribute a2 = dataset.createAttribute<combigrid::real>(
+          "simulation_time", HighFive::DataSpace::From(tasks_[i]->getCurrentTime()));
       a2.write(tasks_[i]->getCurrentTime());
     }
   }
-#else // if not compiled with hdf5
+#else  // if not compiled with hdf5
   throw std::runtime_error("requesting hdf5 write but built without hdf5 support");
 #endif
 }

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.hpp
@@ -89,8 +89,11 @@ class ProcessGroupWorker {
   /** evaluate norms of combi solution error on reference grid  */
   void evalErrorOnDFG();
 
-  /** interpolate values on all tasks' component grids  */
+  /** interpolate values on all tasks' component grids and send back combined result  */
   std::vector<CombiDataType> interpolateValues();
+
+  /** interpolate values on all tasks' component grids and write results to file */
+  void writeInterpolatedValuesPerGrid();
 
   /** update combination parameters (for init or after change in FTCT) */
   void updateCombiParameters();

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
@@ -469,6 +469,18 @@ std::vector<CombiDataType> ProcessManager::interpolateValues(const std::vector<s
   return reducedValues;
 }
 
+void ProcessManager::writeInterpolatedValues(const std::vector<std::vector<real>>& interpolationCoords) {
+  // send interpolation coords as a single array
+  std::vector<real> interpolationCoordsSerial = serializeInterpolationCoords(interpolationCoords);
+
+  for (size_t i = 0; i < pgroups_.size(); ++i) {
+    pgroups_[i]->writeInterpolatedValues(interpolationCoordsSerial);
+  }
+}
+
+// void ProcessManager::writeInterpolationCoordinates(const std::vector<std::vector<real>>& interpolationCoords) {}
+
+
 void ProcessManager::writeSparseGridMinMaxCoefficients(const std::string& filename) {
   pgroups_.back()->writeSparseGridMinMaxCoefficients(filename);
 }

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
@@ -478,7 +478,9 @@ void ProcessManager::writeInterpolatedValues(const std::vector<std::vector<real>
   }
 }
 
-// void ProcessManager::writeInterpolationCoordinates(const std::vector<std::vector<real>>& interpolationCoords) {}
+void ProcessManager::writeInterpolationCoordinates(const std::vector<std::vector<real>>& interpolationCoords) {
+  throw std::runtime_error("not yet implemented");
+}
 
 
 void ProcessManager::writeSparseGridMinMaxCoefficients(const std::string& filename) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.cpp
@@ -5,6 +5,13 @@
 #include "sgpp/distributedcombigrid/utils/Types.hpp"
 #include "sgpp/distributedcombigrid/mpi/MPIUtils.hpp"
 
+#ifdef HAVE_HIGHFIVE
+#include <chrono>
+#include <random>
+// highfive is a C++ hdf5 wrapper, available in spack (-> configure with right boost and mpi versions)
+#include <highfive/H5File.hpp>
+#endif
+
 namespace combigrid {
 
 ProcessManager::~ProcessManager() {}
@@ -469,7 +476,8 @@ std::vector<CombiDataType> ProcessManager::interpolateValues(const std::vector<s
   return reducedValues;
 }
 
-void ProcessManager::writeInterpolatedValues(const std::vector<std::vector<real>>& interpolationCoords) {
+void ProcessManager::writeInterpolatedValues(
+    const std::vector<std::vector<real>>& interpolationCoords) {
   // send interpolation coords as a single array
   std::vector<real> interpolationCoordsSerial = serializeInterpolationCoords(interpolationCoords);
 
@@ -478,10 +486,32 @@ void ProcessManager::writeInterpolatedValues(const std::vector<std::vector<real>
   }
 }
 
-void ProcessManager::writeInterpolationCoordinates(const std::vector<std::vector<real>>& interpolationCoords) {
-  throw std::runtime_error("not yet implemented");
-}
+void ProcessManager::writeInterpolationCoordinates(
+    const std::vector<std::vector<real>>& interpolationCoords) {
+#ifdef HAVE_HIGHFIVE
+  // generate a rank-local per-run random number
+  // std::random_device dev;
+  static std::mt19937 rng(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+  static std::uniform_int_distribution<std::mt19937::result_type> dist(
+      1, std::numeric_limits<size_t>::max());
+  static size_t rankLocalRandom = dist(rng);
 
+  std::string saveFilePath = "interpolation_coords.h5";
+  // check if file already exists, if no, create
+  HighFive::File h5_file(saveFilePath, HighFive::File::OpenOrCreate | HighFive::File::ReadWrite);
+
+  std::string groupName = "run_" + std::to_string(rankLocalRandom);
+  HighFive::Group group = h5_file.createGroup(groupName);
+
+  std::string datasetName = "coordinates";
+  HighFive::DataSet dataset =
+      group.createDataSet<real>(datasetName, HighFive::DataSpace::From(interpolationCoords));
+  dataset.write(interpolationCoords);
+
+#else  // if not compiled with hdf5
+  throw std::runtime_error("requesting hdf5 write but built without hdf5 support");
+#endif
+}
 
 void ProcessManager::writeSparseGridMinMaxCoefficients(const std::string& filename) {
   pgroups_.back()->writeSparseGridMinMaxCoefficients(filename);

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessManager.hpp
@@ -99,6 +99,10 @@ class ProcessManager {
 
   std::vector<CombiDataType> interpolateValues(const std::vector<std::vector<real>>& interpolationCoords);
 
+  void writeInterpolatedValues(const std::vector<std::vector<real>>& interpolationCoords);
+
+  void writeInterpolationCoordinates(const std::vector<std::vector<real>>& interpolationCoords);
+
   void writeSparseGridMinMaxCoefficients(const std::string& filename);
 
   void redistribute(std::vector<size_t>& taskID);

--- a/distributedcombigrid/tests/TaskCount.hpp
+++ b/distributedcombigrid/tests/TaskCount.hpp
@@ -69,6 +69,8 @@ class TaskCount : public combigrid::Task {
 
     BOOST_CHECK(dfg_);
 
+    time_ += 1.;
+
     setFinished(true);
 
     MPI_Barrier(lcomm);
@@ -92,6 +94,10 @@ class TaskCount : public combigrid::Task {
     BOOST_TEST_CHECKPOINT("TaskCount destructor");
   }
 
+  real getCurrentTime() const override {
+    return time_;
+  }
+
  protected:
   TaskCount() : dfg_(NULL) {}
 
@@ -99,6 +105,8 @@ class TaskCount : public combigrid::Task {
   friend class boost::serialization::access;
 
   DistributedFullGrid<CombiDataType>* dfg_;
+
+  combigrid::real time_ = 0.;
 
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version) {

--- a/distributedcombigrid/tests/test_distributedsparsegrid.cpp
+++ b/distributedcombigrid/tests/test_distributedsparsegrid.cpp
@@ -107,6 +107,8 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, IndexVecto
 
     // make sure that right min/max values are written
     uniDSG->writeMinMaxCoefficents("sparse_paraboloid_minmax_" + std::to_string(size), 0);
+    // and remove straight away
+    system( "rm sparse_paraboloid_minmax_*" );
 
     // std::cout << *uniDSG << std::endl;
 
@@ -152,6 +154,12 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, IndexVecto
         BOOST_CHECK_EQUAL(sgDOF, sumDOFPartitioned);
       }
     }
+    // test for dumping sparse grid data to disk and reading back in
+    uniDSG->writeToDisk("test_sg_");
+    uniDSG->readFromDisk("test_sg_");
+
+    // and remove straight away
+    system( "rm test_sg_*" );
 
     // TODO test for reduced lmax
   }

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -842,6 +842,10 @@ BOOST_AUTO_TEST_CASE(test_41) {
   TestFn_3 testFn(levels);
   checkHierarchization(testFn, levels, procs, boundary, 9, true);
 }
+
+// these large tests only make sense when assertions are not checked (takes too long otherwise)
+#ifdef NDEBUG
+
 BOOST_AUTO_TEST_CASE(test_42) {
   // large test case with timing
   MPI_Barrier(MPI_COMM_WORLD);
@@ -905,6 +909,8 @@ BOOST_AUTO_TEST_CASE(test_44) {
   }
   // on ipvs-epyc2@  : 3100 milliseconds w single msgs
 }
+
+#endif // def NDEBUG
 
 BOOST_AUTO_TEST_CASE(momentum) {
   BOOST_REQUIRE(TestHelper::checkNumMPIProcsAvailable(1));

--- a/distributedcombigrid/tests/test_integration.cpp
+++ b/distributedcombigrid/tests/test_integration.cpp
@@ -191,15 +191,17 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
         BOOST_CHECK_CLOSE(std::real(ref), std::real(values[i]), TestHelper::tolerance);
       }
 #ifdef HAVE_HIGHFIVE
-      manager.writeInterpolatedValues(interpolationCoords);
-      BOOST_TEST_CHECKPOINT("wrote interpolated values");
-      manager.writeInterpolationCoordinates(interpolationCoords);
-      BOOST_TEST_CHECKPOINT("wrote interpolation coordinates");
       // output files are not needed, remove them right away
       // (if this doesn't happen, there may be hdf5 errors due to duplicate task IDs)
       sleep(1);
       system("rm interpolated_*.h5");
-      system("rm interpolation_coords.h5");
+      // system("rm interpolation_coords.h5");
+      remove("interpolation_coords.h5");
+      sleep(1);
+      manager.writeInterpolatedValues(interpolationCoords);
+      BOOST_TEST_CHECKPOINT("wrote interpolated values");
+      manager.writeInterpolationCoordinates(interpolationCoords);
+      BOOST_TEST_CHECKPOINT("wrote interpolation coordinates");
 #endif  // def HAVE_HIGHFIVE
     }
 

--- a/distributedcombigrid/tests/test_integration.cpp
+++ b/distributedcombigrid/tests/test_integration.cpp
@@ -121,6 +121,10 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
       taskIDs.push_back(t->getID());
     }
 
+    // why are there duplicate task IDs over different calls to this function??
+    // ah its because different ranks will be master, so there are different Task::count instances
+    // std::cout << "taskIDs " << taskIDs << std::endl;
+
     // create combiparameters
     CombiParameters params(dim, lmin, lmax, boundary, levels, coeffs, taskIDs, ncombi);
     params.setParallelization({static_cast<IndexType>(nprocs), 1});
@@ -186,8 +190,17 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
         BOOST_CHECK_CLOSE(std::abs(ref), std::abs(values[i]), TestHelper::tolerance);
         BOOST_CHECK_CLOSE(std::real(ref), std::real(values[i]), TestHelper::tolerance);
       }
+#ifdef HAVE_HIGHFIVE
       manager.writeInterpolatedValues(interpolationCoords);
+      BOOST_TEST_CHECKPOINT("wrote interpolated values");
       manager.writeInterpolationCoordinates(interpolationCoords);
+      BOOST_TEST_CHECKPOINT("wrote interpolation coordinates");
+      // output files are not needed, remove them right away
+      // (if this doesn't happen, there may be hdf5 errors due to duplicate task IDs)
+      sleep(1);
+      system("rm interpolated_*.h5");
+      system("rm interpolation_coords.h5");
+#endif  // def HAVE_HIGHFIVE
     }
 
     manager.exit();

--- a/distributedcombigrid/tests/test_integration.cpp
+++ b/distributedcombigrid/tests/test_integration.cpp
@@ -186,6 +186,8 @@ void checkIntegration(size_t ngroup = 1, size_t nprocs = 1, bool boundaryV = tru
         BOOST_CHECK_CLOSE(std::abs(ref), std::abs(values[i]), TestHelper::tolerance);
         BOOST_CHECK_CLOSE(std::real(ref), std::real(values[i]), TestHelper::tolerance);
       }
+      manager.writeInterpolatedValues(interpolationCoords);
+      manager.writeInterpolationCoordinates(interpolationCoords);
     }
 
     manager.exit();

--- a/site_scons/ModuleHelper.py
+++ b/site_scons/ModuleHelper.py
@@ -107,8 +107,10 @@ class Module(object):
     # export library name and dependencies
     libname = self.libname
     env.Export("libname")
-    moduleDependencies = self.moduleDependencies
     env.Export("moduleDependencies")
+
+    if env["USE_HDF5"]:
+      self.moduleDependencies.append("hdf5")
 
     if env["BUILD_STATICLIB"]:
       # build static library

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -108,7 +108,7 @@ def doConfigure(env, moduleFolders, languageWrapperFolders):
     # config.env.AppendUnique(LIBPATH=['/usr/local.nfs/sw/cuda/cuda-7.5/'])
 
     # glpk library
-  config.env.AppendUnique(CPPPATH=[config.env['GLPK_INCLUDE_PATH']])   
+  config.env.AppendUnique(CPPPATH=[config.env['GLPK_INCLUDE_PATH']])
   config.env.AppendUnique(LIBPATH=[config.env['GLPK_LIBRARY_PATH']])
 
   checkBoostTests(config)
@@ -144,7 +144,7 @@ def checkDoxygen(config):
 def checkDot(config):
   if not config.env["DOC"]:
     return
-  
+
   # check whether dot installed
   if not config.CheckExec("dot"):
     Helper.printWarning("dot (Graphviz) cannot be found.",
@@ -177,7 +177,7 @@ def checkOpenCL(config):
       Helper.printErrorAndExit("libOpenCL not found, but required for OpenCL")
 
     # TODO: continue - add boost include path!
-    config.env.AppendUnique(LIBPATH="C:\\boost_1_60_0\stage\lib")    
+    config.env.AppendUnique(LIBPATH="C:\\boost_1_60_0\stage\lib")
 
     if not config.CheckLib("boost_program_options", language="c++", autoadd=0):
       Helper.printErrorAndExit("libboost-program-options not found, but required for OpenCL",
@@ -210,6 +210,25 @@ def checkBoostTests(config):
                           "Please install the corresponding package, e.g., on Ubuntu",
                           "> sudo apt-get install libboost-test-dev",
                           "****************************************************")
+
+# def checkHDF5(config):
+#   # Check the availability of hdf libs
+#   hdf5Found = True
+#   if not config.CheckHeader(os.path.join("boost", "test", "unit_test.hpp"), language="c++"):
+#     config.env["COMPILE_BOOST_TESTS"] = False
+#     Helper.printWarning("****************************************************",
+#                         "No Boost Unit Test Headers found. Omitting Boost unit tests.",
+#                         "Please install the corresponding package, e.g., on Ubuntu",
+#                         "> sudo apt-get install libboost-test-dev",
+#                         "****************************************************")
+
+#   if not config.CheckLib("boost_unit_test_framework", autoadd=0, language="c++"):
+#     config.env["COMPILE_BOOST_TESTS"] = False
+#     Helper.printWarning("****************************************************",
+#                         "No Boost Unit Test library found. Omitting Boost unit tests.",
+#                         "Please install the corresponding package, e.g., on Ubuntu",
+#                         "> sudo apt-get install libboost-test-dev",
+#                         "****************************************************")
 
 def checkSWIG(config):
   if config.env["SG_PYTHON"] or config.env["SG_JAVA"]:
@@ -342,11 +361,11 @@ def configureGNUCompiler(config):
 
   # required for profiling
   config.env.Append(CPPFLAGS=["-fno-omit-frame-pointer"])
-  
+
   print("config: "+ str(config.env))
 
   if config.env["DEBUG_OUTPUT"]:
-    config.env.Append(CPPFLAGS=["-DDEBUG_OUTPUT"])  
+    config.env.Append(CPPFLAGS=["-DDEBUG_OUTPUT"])
   if config.env["TIMING"]:
     config.env.Append(CPPFLAGS=["-DTIMING"])
   if config.env["BUILD_STATICLIB"]:
@@ -358,8 +377,10 @@ def configureGNUCompiler(config):
     config.env.Append(CPPFLAGS=["-DOMITREADYSIGNAL"])
   if config.env["UNIFORMDECOMPOSITION"]:
     config.env.Append(CPPFLAGS=["-DUNIFORMDECOMPOSITION"])
+  if config.env["USE_HDF5"]:
+    config.env.Append(CPPFLAGS=["-DHAVE_HIGHFIVE"])
   if config.env["ENABLEFT"]:
-    config.env.Append(CPPFLAGS=["-DENABLEFT"])  
+    config.env.Append(CPPFLAGS=["-DENABLEFT"])
   if config.env["ISGENE"]:
     config.env.Append(CPPFLAGS=["-DISGENE"])
 
@@ -412,7 +433,7 @@ def configureClangCompiler(config):
   #     http://www.swig.org/Release/CHANGES, 03/02/2006
   #    "If you are going to use optimisations turned on with gcc > 4.0 (for example -O2),
   #     ensure you also compile with -fno-strict-aliasing"
-  
+
   config.env.Append(CPPFLAGS=allWarnings + [
       "-DDEFAULT_RES_THRESHOLD=-1.0", "-DTASKS_PARALLEL_UPDOWN=4"])
   config.env.Append(CPPFLAGS=["-fopenmp=libiomp5"])
@@ -420,7 +441,7 @@ def configureClangCompiler(config):
 
   if config.env["DEBUG_OUTPUT"]:
     config.env.Append(CPPFLAGS=["-DDEBUG_OUTPUT"])
-  
+
 
   if config.env["BUILD_STATICLIB"]:
     config.env.Append(CPPFLAGS=["-D_BUILD_STATICLIB"])


### PR DESCRIPTION
Introduces functions to:
* read and write sparse grid data chunks as binary files
* write HDF5 files of interpolated data (put `USE_HDF5` flag into scons call; requires HighFive to be installed, e.g. via spack)