### PR TITLE
Task implementations: avoid calls to MPI_Comm_rank

### DIFF
--- a/distributedcombigrid/examples/combi_example/TaskExample.hpp
+++ b/distributedcombigrid/examples/combi_example/TaskExample.hpp
@@ -34,8 +34,7 @@ class TaskExample : public Task {
     assert(!initialized_);
     assert(dfg_ == NULL);
 
-    int lrank;
-    MPI_Comm_rank(lcomm, &lrank);
+    int lrank = theMPISystem()->getLocalRank();
 
     /* create distributed full grid. we try to find a balanced ratio between
      * the number of grid points and the number of processes per dimension
@@ -107,8 +106,7 @@ class TaskExample : public Task {
   void run(CommunicatorType lcomm) {
     assert(initialized_);
 
-    int lrank;
-    MPI_Comm_rank(lcomm, &lrank);
+    int lrank = theMPISystem()->getLocalRank();
 
     std::vector<CombiDataType>& elements = dfg_->getElementVector();
     // TODO if your Example uses another data structure, you need to copy

--- a/distributedcombigrid/examples/combi_example_faults/TaskExample.hpp
+++ b/distributedcombigrid/examples/combi_example_faults/TaskExample.hpp
@@ -34,8 +34,7 @@ class TaskExample: public Task {
     assert(!initialized_);
     assert(dfg_ == NULL);
 
-    int lrank;
-    MPI_Comm_rank(lcomm, &lrank);
+    int lrank = theMPISystem()->getLocalRank();
 
     /* create distributed full grid. we try to find a balanced ratio between
      * the number of grid points and the number of processes per dimension
@@ -109,9 +108,8 @@ class TaskExample: public Task {
   void run(CommunicatorType lcomm) {
     assert(initialized_);
 
-    int lrank, globalRank;
-    MPI_Comm_rank(lcomm, &lrank);
-    MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
+    int globalRank = theMPISystem()->getGlobalRank();
+    int lrank = theMPISystem()->getLocalRank();
 
     /* pseudo timestepping to demonstrate the behaviour of your typical
      * time-dependent simulation problem. */
@@ -231,9 +229,9 @@ class TaskExample: public Task {
   void decideToKill(){ //toDo check if combiStep should be included in task and sent to process groups in case of reassignment
     using namespace std::chrono;
 
-    int globalRank;
+    int globalRank = theMPISystem()->getGlobalRank();
     // MPI_Comm_rank(lcomm, &lrank);
-    MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
+    // MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
     //theStatsContainer()->setTimerStop("computeIterationRank" + std::to_string(globalRank));
     //duration<real> dur = high_resolution_clock::now() - startTimeIteration_;
     //real t_iter = dur.count();

--- a/distributedcombigrid/examples/gene_distributed/src/GeneTask.cpp
+++ b/distributedcombigrid/examples/gene_distributed/src/GeneTask.cpp
@@ -142,9 +142,9 @@ void GeneTask::changeDir(CommunicatorType lcomm){
 void GeneTask::decideToKill(){ //toDo check if combiStep should be included in task and sent to process groups in case of reassignment
   using namespace std::chrono;
 
-  int globalRank;
+  int globalRank = theMPISystem()->getGlobalRank();
   // MPI_Comm_rank(lcomm, &lrank);
-  MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
+  // MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
 
   //check if killing necessary
   if (combiStep_ != 0 && faultCriterion_->failNow(combiStep_, -1.0, globalRank)){

--- a/distributedcombigrid/examples/gene_distributed_linear/src/GeneTask.cpp
+++ b/distributedcombigrid/examples/gene_distributed_linear/src/GeneTask.cpp
@@ -154,9 +154,9 @@ void GeneTask::changeDir(CommunicatorType lcomm){
 void GeneTask::decideToKill(){ //toDo check if combiStep should be included in task and sent to process groups in case of reassignment
   using namespace std::chrono;
 
-  int globalRank;
+  int globalRank = theMPISystem()->getGlobalRank();
   // MPI_Comm_rank(lcomm, &lrank);
-  MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
+  // MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
   //theStatsContainer()->setTimerStop("computeIterationRank" + std::to_string(globalRank));
   //duration<real> dur = high_resolution_clock::now() - startTimeIteration_;
   //real t_iter = dur.count();

--- a/distributedcombigrid/tests/test_ftolerance.cpp
+++ b/distributedcombigrid/tests/test_ftolerance.cpp
@@ -175,9 +175,9 @@ class TaskAdvFDM : public combigrid::Task {
   void decideToKill(){ //toDo check if combiStep should be included in task and sent to process groups in case of reassignment
     using namespace std::chrono;
 
-    int globalRank;
+    int globalRank = theMPISystem()->getGlobalRank();
     // MPI_Comm_rank(lcomm, &lrank);
-    MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
+    // MPI_Comm_rank(MPI_COMM_WORLD, &globalRank);
     //theStatsContainer()->setTimerStop("computeIterationRank" + std::to_string(globalRank));
     //duration<real> dur = high_resolution_clock::now() - startTimeIteration_;
     //real t_iter = dur.count();


### PR DESCRIPTION
(especially in decideToKill())
-- and replace them by `theMPISystem` interface calls 