### PR TITLE
Fix hierarchical index set

### DIFF
--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.cpp
@@ -26,19 +26,11 @@ void CombiMinMaxScheme::createClassicalCombischeme() {
   } else {
     c = *std::min_element(cv.begin(), cv.end());
   }
-  LevelVector rlmin(effDim_);
-  for (size_t i = 0; i < rlmin.size(); ++i) {
-    rlmin[i] = lmaxtmp[i] - c;
-  }
-
-  // Define new lmin (dummy dimensions will be fixed later)
   for (size_t i = 0; i < lmin_.size(); ++i) {
     lmin_[i] = lmax_[i] - c;
   }
-  LevelType n = sum(rlmin) + c;
 
-  LevelVector l(effDim_, 0);
-  createLevelsRec(effDim_, n, effDim_, l, lmaxtmp);
+  combigrid::createTruncatedHierarchicalLevels(lmaxtmp, lmintmp, levels_);
 
   // re-insert dummy dimensions left out
   for (size_t i = 0; i < dummyDims.size(); ++i) {
@@ -103,24 +95,6 @@ void CombiMinMaxScheme::makeFaultTolerant() {
         combiSpaces_.push_back(l);
         coefficients_.push_back(0.0);
       }
-    }
-  }
-}
-
-void CombiMinMaxScheme::createLevelsRec(DimType dim, LevelType n, DimType d, LevelVector& l,
-                                        const LevelVector& lmax) {
-  // sum rightmost entries of level vector
-  LevelType lsum(0);
-  for (size_t i = dim; i < l.size(); ++i) lsum += l[i];
-
-  for (LevelType ldim = 1; ldim <= LevelType(n) + LevelType(d) - 1 - lsum; ++ldim) {
-    l[dim - 1] = ldim;
-    if (dim == 1) {
-      if (l <= lmax) {
-        levels_.push_back(l);
-      }
-    } else {
-      createLevelsRec(dim - 1, n, d, l, lmax);
     }
   }
 }

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
@@ -201,7 +201,7 @@ static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
   long long int numDOF = 0;
   CombiMinMaxScheme combischeme(dim, lmin, lmax);
   combischeme.createAdaptiveCombischeme();
-  combischeme.createDownSet();
+  // combischeme.createDownSet();
   auto downSet = combischeme.getDownSet();
   for (const auto& subspaceLevel : downSet) {
     long long int numDOFSpace = 1;
@@ -347,7 +347,7 @@ static inline std::vector<long long int> getPartitionedNumDOFSGAdaptive(
   CombiMinMaxScheme combischeme(dim, lmin, lmax);
   combischeme.createAdaptiveCombischeme();
   // auto downSet = combischeme.getDownSet();
-  combischeme.createDownSet();
+  // combischeme.createDownSet();
   auto downSet2 = combischeme.getDownSet();
   // for (const auto& s : downSet) {
   //   if (std::find(downSet2.begin(), downSet2.end(), s) == downSet2.end()) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
@@ -171,7 +171,7 @@ class CombiMinMaxSchemeFromFile : public CombiMinMaxScheme {
   std::vector<size_t> processGroupNumbers_;
 };
 
-static long long int printCombiDegreesOfFreedom(const std::vector<LevelVector>& combiSpaces) {
+inline long long int printCombiDegreesOfFreedom(const std::vector<LevelVector>& combiSpaces) {
   long long int numDOF = 0;
   for (const auto& space : combiSpaces) {
     long int numDOFSpace = 1;
@@ -191,20 +191,14 @@ static long long int printCombiDegreesOfFreedom(const std::vector<LevelVector>& 
   return numDOF;
 }
 
-static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
-                                                     const LevelVector& lmax) {
-  DimType dim = lmin.size();
+inline long long int getSGDegreesOfFreedomFromDownSet(const std::vector<LevelVector>& downSet) {
   long long int numDOF = 0;
-  CombiMinMaxScheme combischeme(dim, lmin, lmax);
-  combischeme.createAdaptiveCombischeme();
-  // combischeme.createDownSet();
-  auto downSet = combischeme.getDownSet();
   for (const auto& subspaceLevel : downSet) {
     long long int numDOFSpace = 1;
     for (const auto& level_i : subspaceLevel) {
       assert(level_i > -1);
-      // for the weird kind of boundary handling we currently have (the boundary points belong to
-      // level 1)
+      // for the weird kind of boundary handling we currently have
+      // (in the hierarchical spaces, the boundary points belong to level 1)
       assert(level_i > 0);
       if (level_i > 1) {
         numDOFSpace *= powerOfTwo[level_i - 1];
@@ -216,6 +210,17 @@ static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
     //           << numDOFSpace << " DOF " << std::endl;
     numDOF += numDOFSpace;
   }
+  return numDOF;
+}
+
+inline long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
+                                                     const LevelVector& lmax) {
+  DimType dim = lmin.size();
+  CombiMinMaxScheme combischeme(dim, lmin, lmax);
+  combischeme.createAdaptiveCombischeme();
+  // combischeme.createDownSet();
+  auto downSet = combischeme.getDownSet();
+  auto numDOF = getSGDegreesOfFreedomFromDownSet(downSet);
 
   std::cout << "Sparse grid DOF : " << numDOF << " i.e. "
             << (static_cast<double>(numDOF * sizeof(CombiDataType)) / 1e9) << " GB " << std::endl;
@@ -223,7 +228,7 @@ static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
   return numDOF;
 }
 
-static inline IndexType getHighestIndexInHierarchicalSubspaceLowerThanNodalIndexOnLref(
+inline IndexType getHighestIndexInHierarchicalSubspaceLowerThanNodalIndexOnLref(
     LevelType hierarchicalSubspaceLevel, IndexType nodalIndex, LevelType referenceLevel) {
   assert(hierarchicalSubspaceLevel <= referenceLevel);
   IndexType index = -1;
@@ -261,7 +266,7 @@ static inline IndexType getHighestIndexInHierarchicalSubspaceLowerThanNodalIndex
   return index;
 }
 
-static inline std::vector<long long int> getPartitionedNumDOFSG(
+inline std::vector<long long int> getPartitionedNumDOFSG(
     std::vector<LevelVector> downSet, const LevelVector& referenceLevel,
     const std::vector<IndexVector> decomposition) {
   // this is only valid for with-boundary schemes!
@@ -335,7 +340,7 @@ static inline std::vector<long long int> getPartitionedNumDOFSG(
   return numDOF;
 }
 
-static inline std::vector<long long int> getPartitionedNumDOFSGAdaptive(
+inline std::vector<long long int> getPartitionedNumDOFSGAdaptive(
     LevelVector lmin, LevelVector lmax, const LevelVector& referenceLevel,
     const std::vector<IndexVector> decomposition) {
   assert((lmin.size() == lmax.size()) == (referenceLevel.size() == decomposition.size()));
@@ -359,11 +364,8 @@ static inline std::vector<long long int> getPartitionedNumDOFSGAdaptive(
   return getPartitionedNumDOFSG(downSet2, referenceLevel, decomposition);
 }
 
-// for widely-distributed simulations, get the number of DOF that absolutely needs
-// to be exchanged with the other system
-static inline std::vector<long long int> getPartitionedNumDOFSGConjoint(
-    const CombiMinMaxSchemeFromFile& combischeme, const LevelVector& lmin, const LevelVector& referenceLevel,
-    const std::vector<IndexVector> decomposition) {
+inline std::vector<LevelVector> getConjointSet(const CombiMinMaxSchemeFromFile& combischeme,
+                                                      const LevelVector& lmin) {
   // we follow the idea in CombiMinMaxSchemeFromFile::createDownSet
   // but this time we count the occurrences of each grid in the individual downPoleSets
   // if a hierarchical level occurs d times, this means that this space is not required on the other
@@ -404,7 +406,23 @@ static inline std::vector<long long int> getPartitionedNumDOFSGConjoint(
     }
   }
   // std::cout << "Conjoint subspace level : " << conjointSet << std::endl;
+  return conjointSet;
+}
 
+// for widely-distributed simulations, get the number of DOF that absolutely needs
+// to be exchanged with the other system
+inline long long int getNumDOFSGConjoint(
+    const CombiMinMaxSchemeFromFile& combischeme, const LevelVector& lmin) {
+  auto conjointSet = getConjointSet(combischeme, lmin);
+  return getSGDegreesOfFreedomFromDownSet(conjointSet);
+}
+
+// for widely-distributed simulations, get the number of DOF that absolutely needs
+// to be exchanged with the other system -- partitioned
+inline std::vector<long long int> getPartitionedNumDOFSGConjoint(
+    const CombiMinMaxSchemeFromFile& combischeme, const LevelVector& lmin, const LevelVector& referenceLevel,
+    const std::vector<IndexVector> decomposition) {
+  auto conjointSet = getConjointSet(combischeme, lmin);
   return getPartitionedNumDOFSG(conjointSet, referenceLevel, decomposition);
 }
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
@@ -63,6 +63,26 @@ class CombiMinMaxScheme {
     return levels_;
   }
 
+  /**
+   * @brief (re-)generate the downward closed set of the CombiScheme
+   *
+   * (this function is here because I don't understand the levels_ in the code so far,
+   * so I re-implemented the downward closed set from the definition)
+   *
+   */
+  void createDownSet() {
+    std::set<LevelVector> subspaces;
+    for (size_t i = 0; i < combiSpaces_.size(); ++ i) {
+      // only check the active front of the scheme -- those grids with coefficient 1
+      if (coefficients_[i] == 1.) {
+        // insert all subspaces covered by grid i into the set
+        auto thisGridsDownSet = combigrid::getDownSet(combiSpaces_[i]);
+        subspaces.insert(thisGridsDownSet.begin(), thisGridsDownSet.end());
+      }
+    }
+    levels_.assign(subspaces.begin(), subspaces.end());
+  }
+
   inline void print(std::ostream& os) const;
 
  protected:
@@ -183,9 +203,10 @@ static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
   long long int numDOF = 0;
   CombiMinMaxScheme combischeme(dim, lmin, lmax);
   combischeme.createAdaptiveCombischeme();
+  combischeme.createDownSet();
   auto downSet = combischeme.getDownSet();
   for (const auto& subspaceLevel : downSet) {
-    long int numDOFSpace = 1;
+    long long int numDOFSpace = 1;
     for (const auto& level_i : subspaceLevel) {
       assert(level_i > -1);
       // for the weird kind of boundary handling we currently have (the boundary points belong to
@@ -197,6 +218,8 @@ static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
         numDOFSpace *= 3;
       }
     }
+    // std::cout << "Sparse grid subspace level : " << subspaceLevel << " has "
+    //           << numDOFSpace << " DOF " << std::endl;
     numDOF += numDOFSpace;
   }
 
@@ -206,7 +229,7 @@ static long long int printSGDegreesOfFreedomAdaptive(const LevelVector& lmin,
   return numDOF;
 }
 
-static IndexType getHighestIndexInHierarchicalSubspaceLowerThanNodalIndexOnLref(
+static inline IndexType getHighestIndexInHierarchicalSubspaceLowerThanNodalIndexOnLref(
     LevelType hierarchicalSubspaceLevel, IndexType nodalIndex, LevelType referenceLevel) {
   assert(hierarchicalSubspaceLevel <= referenceLevel);
   IndexType index = -1;
@@ -244,14 +267,12 @@ static IndexType getHighestIndexInHierarchicalSubspaceLowerThanNodalIndexOnLref(
   return index;
 }
 
-// TODO add test for this -- to compare to actual sg assigned sizes
-static std::vector<long long int> getPartitionedNumDOFSGAdaptive(
-    LevelVector lmin, LevelVector lmax, const LevelVector& referenceLevel,
+static inline std::vector<long long int> getPartitionedNumDOFSG(
+    std::vector<LevelVector> downSet, const LevelVector& referenceLevel,
     const std::vector<IndexVector> decomposition) {
   // this is only valid for with-boundary schemes!
   // cf downsampleDecomposition to extend to non-boundary
-  assert((lmin.size() == lmax.size()) == (referenceLevel.size() == decomposition.size()));
-  DimType dim = lmin.size();
+  DimType dim = downSet[0].size();
   IndexVector decompositionOffsets;
   IndexType multiplier = 1;
   for (const auto& d : decomposition) {
@@ -261,9 +282,6 @@ static std::vector<long long int> getPartitionedNumDOFSGAdaptive(
   auto numProcsPerGroup = multiplier;
   std::vector<long long int> numDOF(numProcsPerGroup, 0);
 
-  CombiMinMaxScheme combischeme(dim, lmin, lmax);
-  combischeme.createAdaptiveCombischeme();
-  auto downSet = combischeme.getDownSet();
   // iterate subspaces
   for (const auto& subspaceLevel : downSet) {
     // assign decomposition just to set the right vector sizes
@@ -321,6 +339,79 @@ static std::vector<long long int> getPartitionedNumDOFSGAdaptive(
   }
   // std::cout << "numDOF" << numDOF << std::endl;
   return numDOF;
+}
+
+static inline std::vector<long long int> getPartitionedNumDOFSGAdaptive(
+    LevelVector lmin, LevelVector lmax, const LevelVector& referenceLevel,
+    const std::vector<IndexVector> decomposition) {
+  assert((lmin.size() == lmax.size()) == (referenceLevel.size() == decomposition.size()));
+  auto dim = lmin.size();
+  CombiMinMaxScheme combischeme(dim, lmin, lmax);
+  combischeme.createAdaptiveCombischeme();
+  // auto downSet = combischeme.getDownSet();
+  combischeme.createDownSet();
+  auto downSet2 = combischeme.getDownSet();
+  // for (const auto& s : downSet) {
+  //   if (std::find(downSet2.begin(), downSet2.end(), s) == downSet2.end()) {
+  //     std::cout << "in 1 but not 2 : " << s << std::endl;
+  //   }
+  // }
+  // for (const auto& s : downSet2) {
+  //   if (std::find(downSet.begin(), downSet.end(), s) == downSet.end()) {
+  //     std::cout << "in 2 but not 1 : " << s << std::endl;
+  //   }
+  // }
+  // std::cout << "Adaptive subspaces : " << downSet << std::endl;
+  return getPartitionedNumDOFSG(downSet2, referenceLevel, decomposition);
+}
+
+// for widely-distributed simulations, get the number of DOF that absolutely needs
+// to be exchanged with the other system
+static inline std::vector<long long int> getPartitionedNumDOFSGConjoint(
+    const CombiMinMaxSchemeFromFile& combischeme, const LevelVector& lmin, const LevelVector& referenceLevel,
+    const std::vector<IndexVector> decomposition) {
+  // we follow the idea in CombiMinMaxSchemeFromFile::createDownSet
+  // but this time we count the occurrences of each grid in the individual downPoleSets
+  // if a hierarchical level occurs d times, this means that this space is not required on the other
+  // system (unless we have chosen a stupid decomposition -- this should maybe be checked)
+  auto& combiSpaces = combischeme.getCombiSpaces();
+  std::map<LevelVector, size_t> subspaces;
+  // TODO actually, we need to check for the effective dimension
+  //  get the length of level vector for now
+  auto dim = combiSpaces[0].size();
+  for (size_t i = 0; i < combiSpaces.size(); ++i) {
+    // only check the active front of the scheme -- those grids with coefficient 1
+    if (std::abs(combischeme.getCoeffs()[i] - 1.) < 1e-9) {
+      // insert all subspaces "covered" by grid i into the map
+      // iterate dimensions
+      for (DimType d = 0; d < dim; ++d) {
+        // iterate the downward pole in that dimension, leave out grid itself
+        for (LevelType l_j = lmin[d]; l_j < combiSpaces[i][d]; ++l_j) {
+          auto subspace = combiSpaces[i];
+          subspace[d] = l_j;
+          subspaces[subspace] += 1;
+        }
+      }
+    }
+  }
+  // std::cout << "Conjoint subspace map : " << subspaces << std::endl;
+
+  std::vector<LevelVector> conjointSet;
+  for (const auto& item : subspaces) {
+    if (item.second < dim) {
+      conjointSet.push_back(item.first);
+      // make the conjoint set downward closed
+      auto thisGridsDownSet = combigrid::getDownSet(item.first);
+      for (const auto& downSpace : thisGridsDownSet) {
+        if (std::find(conjointSet.begin(), conjointSet.end(), downSpace) == conjointSet.end()) {
+          conjointSet.push_back(downSpace);
+        }
+      }
+    }
+  }
+  // std::cout << "Conjoint subspace level : " << conjointSet << std::endl;
+
+  return getPartitionedNumDOFSG(conjointSet, referenceLevel, decomposition);
 }
 
 }  // namespace combigrid

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
@@ -110,10 +110,6 @@ class CombiMinMaxScheme {
   /* Combination coefficients */
   std::vector<real> coefficients_;
 
-  /* Creates the downset recursively */
-  void createLevelsRec(DimType dim, LevelType n, DimType d, LevelVector& l,
-                       const LevelVector& lmax);
-
   /* Calculate the coefficients of the classical CT (binomial coefficient)*/
   void computeCombiCoeffsClassical();
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/combischeme/CombiMinMaxScheme.hpp
@@ -120,8 +120,6 @@ class CombiMinMaxScheme {
   /* Calculate the coefficients of the adaptive CT using the formula in Alfredo's
    * SDC paper (from Brendan Harding)*/
   void computeCombiCoeffsAdaptive();
-
-  LevelVector getLevelMinima();
 };
 
 inline std::ostream& operator<<(std::ostream& os, const combigrid::CombiMinMaxScheme& scheme) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGrid.hpp
@@ -129,8 +129,6 @@ class DistributedSparseGrid {
  private:
   void createLevels(DimType dim, const LevelVector& nmax, const LevelVector& lmin);
 
-  void createLevelsRec(size_t dim, size_t n, size_t d, LevelVector& l, const LevelVector& nmax);
-
   void setSizes();
 
   void calcProcAssignment(int procsPerNode);
@@ -223,60 +221,10 @@ std::ostream& operator<<(std::ostream& os, const DistributedSparseGrid<FG_ELEMEN
 template <typename FG_ELEMENT>
 DistributedSparseGrid<FG_ELEMENT>::~DistributedSparseGrid() {}
 
-// start recursion by setting dim=d=dimensionality of the vector space
-template <typename FG_ELEMENT>
-void DistributedSparseGrid<FG_ELEMENT>::createLevelsRec(size_t dim, size_t n, size_t d,
-                                                        LevelVector& l, const LevelVector& nmax) {
-  // sum rightmost entries of level vector
-  LevelType lsum(0);
-
-  for (size_t i = dim; i < l.size(); ++i) lsum += l[i];
-
-  for (LevelType ldim = 1; ldim <= LevelType(n) + LevelType(d) - 1 - lsum; ++ldim) {
-    l[dim - 1] = ldim;
-
-    if (dim == 1) {
-      if (l <= nmax) {
-        levels_.push_back(l);
-        // std::cout << l << std::endl;
-      }
-    } else {
-      createLevelsRec(dim - 1, n, d, l, nmax);
-    }
-  }
-}
-
 template <typename FG_ELEMENT>
 void DistributedSparseGrid<FG_ELEMENT>::createLevels(DimType dim, const LevelVector& nmax,
                                                      const LevelVector& lmin) {
-  assert(nmax.size() == dim);
-  assert(lmin.size() == dim);
-
-  // compute c which fulfills nmax - c*1  >= lmin
-
-  LevelVector ltmp(nmax);
-  LevelType c = 0;
-
-  while (ltmp > lmin) {
-    ++c;
-
-    for (size_t i = 0; i < dim; ++i) {
-      ltmp[i] = nmax[i] - c;
-
-      if (ltmp[i] < 1) ltmp[i] = 1;
-    }
-  }
-
-  LevelVector rlmin(dim);
-
-  for (size_t i = 0; i < rlmin.size(); ++i) {
-    rlmin[i] = nmax[i] - c;
-  }
-
-  LevelType n = sum(rlmin) + c - dim + 1;
-
-  LevelVector l(dim);
-  createLevelsRec(dim, n, dim, l, nmax);
+  assert(false); //TODO steal back from DistributedSparseGridUniform
 }
 
 template <typename FG_ELEMENT>

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
@@ -82,6 +82,9 @@ class DistributedSparseGridUniform {
   // creates data if necessary and sets all data elements to zero
   void setZero();
 
+  // return all level vectors
+  inline const std::vector<LevelVector>& getAllLevelVectors() const;
+
   // return level vector of subspace i
   inline const LevelVector& getLevelVector(size_t i) const;
 
@@ -343,6 +346,12 @@ std::vector<LevelVector> DistributedSparseGridUniform<FG_ELEMENT>::createLevels(
 //     subspaces_[i].size_ = size_t(tmp);
 //   }
 // }
+
+template <typename FG_ELEMENT>
+inline const std::vector<LevelVector>&
+DistributedSparseGridUniform<FG_ELEMENT>::getAllLevelVectors() const {
+  return levels_;
+}
 
 template <typename FG_ELEMENT>
 inline const LevelVector& DistributedSparseGridUniform<FG_ELEMENT>::getLevelVector(size_t i) const {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
@@ -159,9 +159,6 @@ class DistributedSparseGridUniform {
  private:
   std::vector<LevelVector> createLevels(DimType dim, const LevelVector& nmax, const LevelVector& lmin);
 
-  void createLevelsRec(size_t dim, size_t n, size_t d, LevelVector& l, const LevelVector& nmax,
-                       std::vector<LevelVector>& created) const;
-
   // void setSizes();
 
   DimType dim_;
@@ -208,10 +205,10 @@ DistributedSparseGridUniform<FG_ELEMENT>::DistributedSparseGridUniform(
     const std::vector<bool>& boundary,
     CommunicatorType comm,
     size_t procsPerNode /*= 0*/)
-    : boundary_(boundary),
-      comm_(comm),
-      dim_(dim),
+    : dim_(dim),
       levels_(subspaces),
+      boundary_(boundary),
+      comm_(comm),
       subspacesDataSizes_(subspaces.size())
 {
   assert(dim > 0);
@@ -313,62 +310,11 @@ std::ostream& operator<<(std::ostream& os, const DistributedSparseGridUniform<FG
 template <typename FG_ELEMENT>
 DistributedSparseGridUniform<FG_ELEMENT>::~DistributedSparseGridUniform() {}
 
-// start recursion by setting dim=d=dimensionality of the vector space
 template <typename FG_ELEMENT>
-void DistributedSparseGridUniform<FG_ELEMENT>::createLevelsRec(size_t dim, size_t n, size_t d,
-                                                               LevelVector& l,
-                                                               const LevelVector& nmax, std::vector<LevelVector>& created) const {
-  // sum rightmost entries of level vector
-  LevelType lsum(0);
-
-  for (size_t i = dim; i < l.size(); ++i) lsum += l[i];
-
-  for (LevelType ldim = 1; ldim <= LevelType(n) + LevelType(d) - 1 - lsum; ++ldim) {
-    l[dim - 1] = ldim;
-
-    if (dim == 1) {
-      if (l <= nmax) {
-        created.push_back(l);
-        // std::cout << l << std::endl;
-      }
-    } else {
-      createLevelsRec(dim - 1, n, d, l, nmax, created);
-    }
-  }
-}
-
-template <typename FG_ELEMENT>
-std::vector<LevelVector> DistributedSparseGridUniform<FG_ELEMENT>::createLevels(DimType dim, const LevelVector& nmax,
-                                                            const LevelVector& lmin) {
-  assert(nmax.size() == dim);
-  assert(lmin.size() == dim);
-
-  // compute c which fulfills nmax - c*1  >= lmin
-
-  LevelVector ltmp(nmax);
-  LevelType c = 0;
-
-  while (ltmp > lmin) {
-    ++c;
-
-    for (size_t i = 0; i < dim; ++i) {
-      ltmp[i] = nmax[i] - c;
-
-      if (ltmp[i] < 1) ltmp[i] = 1;
-    }
-  }
-
-  LevelVector rlmin(dim);
-
-  for (size_t i = 0; i < rlmin.size(); ++i) {
-    rlmin[i] = nmax[i] - c;
-  }
-
-  LevelType n = sum(rlmin) + c - dim + 1;
-
-  LevelVector l(dim);
-  std::vector<LevelVector> created {};
-  createLevelsRec(dim, n, dim, l, nmax, created);
+std::vector<LevelVector> DistributedSparseGridUniform<FG_ELEMENT>::createLevels(
+    DimType dim, const LevelVector& nmax, const LevelVector& lmin) {
+  std::vector<LevelVector> created{};
+  combigrid::createTruncatedHierarchicalLevels(nmax, lmin, created);
   return created;
 }
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/SGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/SGrid.hpp
@@ -229,8 +229,6 @@ SGrid<FG_ELEMENT>::SGrid(DimType dim, const LevelVector& nmax, const LevelVector
   lmin_ = lmin;
   boundary_ = boundary;
 
-
-  std::cout << "SGrid "  << (nmax)  << (lmin) << std::endl;
   createLevels(dim, nmax_, lmin_);
 
   data_.resize(levels_.size());

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.cpp
@@ -32,4 +32,94 @@ std::vector<LevelVector> getDownSet(combigrid::LevelVector const& l) {
   getDownSetRecursively(l, LevelVector(), downSet);
   return downSet;
 }
+
+// cf.
+// https://stackoverflow.com/questions/12991758/creating-all-possible-k-combinations-of-n-items-in-c
+std::vector<std::vector<DimType>> getAllKOutOfDDimensions(DimType k, DimType d) {
+  std::vector<std::vector<DimType>> combinations;
+  std::vector<DimType> selected;
+  std::vector<DimType> selector(d);
+  std::fill(selector.begin(), selector.begin() + k, 1);
+  do {
+    for (DimType i = 0; i < d; i++) {
+      if (selector[i]) {
+        selected.push_back(i);
+      }
+    }
+    combinations.push_back(selected);
+    selected.clear();
+  } while (std::prev_permutation(selector.begin(), selector.end()));
+  return combinations;
+}
+
+void createTruncatedHierarchicalLevelsRec(size_t dim, size_t n, LevelVector& l,
+                                        const LevelVector& lmax, const LevelVector& lmin,
+                                        std::vector<LevelVector>& created) {
+  // sum rightmost entries of level vector
+  LevelType lsum(0);
+  for (size_t i = dim; i < l.size(); ++i) {
+    lsum += l[i];
+  }
+
+  // iterate everything below hyperplane
+  for (LevelType ldim = 1; ldim <= LevelType(sum(lmin) + n) - lsum; ++ldim) {
+    // smallereq than lmax in every dim
+    if (ldim > lmax[dim - 1]) {
+      continue;
+    } else {
+      l[dim - 1] = ldim;
+      if (dim == 1) {
+        // all mixed dimension sums
+        bool pleaseAdd = true;
+        DimType d = lmin.size();
+        for (DimType k = 2; k <= d; ++k) {
+          auto dimList = getAllKOutOfDDimensions(k, d);
+          // for each subselection of dimensions, compute sum of l and lmin
+          for (const auto& dimCombination : dimList) {
+            LevelType partlsum(0), partlminsum(0);
+            for (const auto& i : dimCombination) {
+              partlsum += l[i];
+              partlminsum += lmin[i];
+            }
+            if ((partlsum > static_cast<LevelType>(partlminsum + n))) {
+              // std::cout << k << " k " << l << partlsum << " " << dimCombination << " other stop "
+              // << partlminsum << " n " << n << std::endl;
+              pleaseAdd = false;
+              break;
+            }
+          }
+        }
+        if (pleaseAdd) {
+          created.push_back(l);
+        }
+      } else {
+        createTruncatedHierarchicalLevelsRec(dim - 1, n, l, lmax, lmin, created);
+      }
+    }
+  }
+}
+
+void createTruncatedHierarchicalLevels(const LevelVector& lmax,
+                                     const LevelVector& lmin, std::vector<LevelVector>& created) {
+  auto dim = lmax.size();
+  assert(lmin.size() == dim);
+
+  LevelVector ldiff = lmax - lmin;
+  LevelType minLevelDifference = *(std::min_element(ldiff.begin(), ldiff.end()));
+
+  //TODO currently, we basically enlarge the sparse grid
+  // (potentially more hierarchical subspaces than necessary for scheme!)
+  // it is fine for evenly spaced level differences though
+  LevelVector rlmin(dim);
+
+  for (size_t i = 0; i < rlmin.size(); ++i) {
+    rlmin[i] = lmax[i] - minLevelDifference;
+  }
+
+  LevelType n = minLevelDifference;
+
+  LevelVector l(dim);
+  createTruncatedHierarchicalLevelsRec(dim, n, l, lmax, rlmin, created);
+}
+
 }  // namespace combigrid

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.cpp
@@ -1,16 +1,35 @@
 
 #include "sgpp/distributedcombigrid/utils/LevelVector.hpp"
 
-namespace combigrid{
-    std::string toString(combigrid::LevelVector const& l){
-        std::stringstream ss;
-        for(size_t i = 0; i < l.size(); ++i)
-        {
-            if(i != 0)
-                ss << ",";
-            ss << l[i];
-        }
-        return ss.str();
-    }
+namespace combigrid {
+std::string toString(combigrid::LevelVector const& l) {
+  std::stringstream ss;
+  for (size_t i = 0; i < l.size(); ++i) {
+    if (i != 0) ss << ",";
+    ss << l[i];
+  }
+  return ss.str();
 }
 
+void getDownSetRecursively(combigrid::LevelVector const& l, combigrid::LevelVector fixedDimensions,
+                           std::vector<LevelVector>& downSet) {
+  if (fixedDimensions.size() == l.size()) {
+    downSet.push_back(fixedDimensions);
+  } else {
+    // for the whole range of values in dimension d
+    size_t d = fixedDimensions.size();
+    for (LevelType i = 1; i <= l[d]; ++i) {  // levels start at 1 here, in compliance with our
+                                         // definition of DistributedSparseGrid
+      auto moreDimensionsFixed = fixedDimensions;
+      moreDimensionsFixed.push_back(i);
+      getDownSetRecursively(l, moreDimensionsFixed, downSet);
+    }
+  }
+}
+
+std::vector<LevelVector> getDownSet(combigrid::LevelVector const& l) {
+  std::vector<LevelVector> downSet;
+  getDownSetRecursively(l, LevelVector(), downSet);
+  return downSet;
+}
+}  // namespace combigrid

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.cpp
@@ -55,6 +55,8 @@ std::vector<std::vector<DimType>> getAllKOutOfDDimensions(DimType k, DimType d) 
 void createTruncatedHierarchicalLevelsRec(size_t dim, size_t n, LevelVector& l,
                                         const LevelVector& lmax, const LevelVector& lmin,
                                         std::vector<LevelVector>& created) {
+  assert(lmax[dim-1] == lmin[dim-1] + n);
+
   // sum rightmost entries of level vector
   LevelType lsum(0);
   for (size_t i = dim; i < l.size(); ++i) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.hpp
@@ -13,6 +13,29 @@ std::string toString(combigrid::LevelVector const& l);
 // get downward closed set of a single LevelVector
 std::vector<LevelVector> getDownSet(combigrid::LevelVector const& l);
 
+/**
+ * @brief recursively generate a downward-closed set of hierarchical level vectors
+ *
+ * @param dim : the currently recursively iterated dimension
+ * @param n : the "regular level", here the minimum of the difference of lmax and lmin
+ * @param d : the dimensionality
+ * @param l : the currently populated level vector (entries filled only from dim to d-1)
+ * @param lmax
+ * @param lmin
+ *
+ *  start recursion by setting dim=d=dimensionality of the vector space
+    for correct subspace restriction in d > 2, we need 3 criteria:
+    the diagonal hyperplane that restricts to the simplex,
+    the maximum of lmax in every dimension, and
+    the mixed dimension sum restrictions
+ */
+void createTruncatedHierarchicalLevelsRec(size_t dim, size_t n, LevelVector& l,
+                                          const LevelVector& lmax, const LevelVector& lmin,
+                                          std::vector<LevelVector>& created);
+
+void createTruncatedHierarchicalLevels(const LevelVector& lmax, const LevelVector& lmin,
+                                       std::vector<LevelVector>& created);
+
 }  // namespace combigrid
 
 #endif /* LEVELVECTOR_HPP_ */

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/utils/LevelVector.hpp
@@ -7,8 +7,12 @@
 
 namespace combigrid {
 
-    typedef IndexVector LevelVector;
-    std::string toString(combigrid::LevelVector const& l);
+typedef IndexVector LevelVector;
+std::string toString(combigrid::LevelVector const& l);
+
+// get downward closed set of a single LevelVector
+std::vector<LevelVector> getDownSet(combigrid::LevelVector const& l);
+
 }  // namespace combigrid
 
 #endif /* LEVELVECTOR_HPP_ */

--- a/distributedcombigrid/tests/test_distributedsparsegrid.cpp
+++ b/distributedcombigrid/tests/test_distributedsparsegrid.cpp
@@ -134,7 +134,9 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, IndexVecto
                                        std::to_string(size) + "_" + std::to_string(boundary[0]),
                                    0);
     // and remove straight away
-    system("rm sparse_paraboloid_minmax_*");
+    if (rank == 0) {
+      system("rm sparse_paraboloid_minmax_*");
+    }
 
     // std::cout << *uniDSG << std::endl;
 
@@ -200,7 +202,9 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, IndexVecto
     uniDSG->readFromDisk("test_sg_");
 
     // and remove straight away
-    system( "rm test_sg_*" );
+    if (rank == 0) {
+      system( "rm test_sg_*" );
+    }
 
     // TODO test for reduced lmax
   }

--- a/distributedcombigrid/tests/test_ftolerance.cpp
+++ b/distributedcombigrid/tests/test_ftolerance.cpp
@@ -305,7 +305,7 @@ for (size_t i = 1; i < ncombi; ++i){
         std::cout << "failed group detected at combi iteration " << i-1<< std::endl;
         //manager.recover();
 
-        std::vector<int> faultsID;
+        std::vector<size_t> faultsID;
 
         //vector with pointers to managers of failed groups
         std::vector< ProcessGroupManagerID> groupFaults;
@@ -313,7 +313,7 @@ for (size_t i = 1; i < ncombi; ++i){
 
         /* call optimization code to find new coefficients */
         const std::string prob_name = "interpolation based optimization";
-        std::vector<int> redistributeFaultsID, recomputeFaultsID;
+        std::vector<size_t> redistributeFaultsID, recomputeFaultsID;
         manager.recomputeOptimumCoefficients(prob_name, faultsID,
                                              redistributeFaultsID, recomputeFaultsID);
         for ( auto id : redistributeFaultsID ) {

--- a/distributedcombigrid/tests/test_reduce.cpp
+++ b/distributedcombigrid/tests/test_reduce.cpp
@@ -78,7 +78,7 @@ class TaskConst : public combigrid::Task {
     setFinished(true);
     
     MPI_Barrier(lcomm);
-    std::cerr << "barrier" << std::endl;
+    // std::cerr << "barrier" << std::endl;
   }
 
   void getFullGrid(FullGrid<CombiDataType>& fg, RankType r, CommunicatorType lcomm, int n = 0) {

--- a/distributedcombigrid/tests/test_stats.cpp
+++ b/distributedcombigrid/tests/test_stats.cpp
@@ -37,7 +37,7 @@ void checkStats(int size){
     combigrid::Stats::finalize();
     // MPI_Barrier(comm);
     BOOST_TEST_CHECKPOINT("stats write");
-    combigrid::Stats::write("./distributedcombigrid/tests/Stats_output", comm);
+    combigrid::Stats::write("test_stats_output", comm);
     // MPI_Barrier(comm);
 }
 


### PR DESCRIPTION
So until now, when we had a truncated combi scheme with dimension > 2, like lmin = [3, 3, 3], lmax=[7, 7, 7], then there would be loads of unnecessary level vectors: for instance, [7, 5, 1] would be included in the scheme. It becomes severe if you go to high dimensions and resolutions, and/or want to use the reduced level vector trick (to avoid communication of the finest resolved hierarchical subspaces).

This was due to mixed dimension level sums not being checked (only single dimensions and the whole level vector sum was restricted). 

This PR puts the functionality into LevelVector.cpp and fixes the issue: `combigrid::createTruncatedHierarchicalLevels` and `combigrid::createTruncatedHierarchicalLevelsRec`. The function is called from the Sparse Grid implementations.

Also, there are more tests for higher dimensionalities of sparse grids.