### PR TITLE
Feature full grid sparse grid mapping

### DIFF
--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -1167,9 +1167,7 @@ class DistributedFullGrid {
    */
   void addToUniformSG(DistributedSparseGridUniform<FG_ELEMENT>& dsg, real coeff) {
     // test if dsg has already been registered
-    if (dsg_ != &dsg) {
-      this->registerUniformSG(dsg);
-    }
+    assert(dsg_ == &dsg);
     assert(dsg.isSubspaceDataCreated());
 
     bool anythingWasAdded = false;
@@ -1206,9 +1204,7 @@ class DistributedFullGrid {
    */
   void extractFromUniformSG(DistributedSparseGridUniform<FG_ELEMENT>& dsg) {
     // test if dsg has already been registered
-    if (dsg_ != &dsg) {
-      this->registerUniformSG(dsg);
-    }
+    assert(dsg_ == &dsg);
     assert(dsg.isSubspaceDataCreated());
 
     // all the hierarchical subspaces contained in this full grid

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -1093,9 +1093,11 @@ class DistributedFullGrid {
    * @return the indices of points on this partition
    */
   inline std::vector<IndexType> getFGPointsOfSubspace(const LevelVector& l) {
-    IndexVector subspaceIndices;
+    static IndexVector subspaceIndices;
+    subspaceIndices.clear();
     IndexType numPointsOfSubspace = 1;
-    auto oneDIndices = std::vector<IndexVector>(dim_);
+    static auto oneDIndices = std::vector<IndexVector>(dim_);
+    oneDIndices.resize(dim_);
     for (DimType d = 0; d < dim_; ++d) {
       if (l[d] > levels_[d]) {
         return subspaceIndices;

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/fullgrid/DistributedFullGrid.hpp
@@ -1166,8 +1166,8 @@ class DistributedFullGrid {
    * @param coeff the coefficient that gets multiplied to all entries
    */
   void addToUniformSG(DistributedSparseGridUniform<FG_ELEMENT>& dsg, real coeff) {
-    // test if dsg has already been registered
-    assert(dsg_ == &dsg);
+    // // test if dsg has already been registered
+    // assert(dsg_ == &dsg);
     assert(dsg.isSubspaceDataCreated());
 
     bool anythingWasAdded = false;
@@ -1180,7 +1180,7 @@ class DistributedFullGrid {
     // loop over all subspaces of the full grid
     for (const auto& level : downwardClosedSet) {
       sIndex = dsg_->getIndexInRange(level, sIndex);
-      if (sIndex > -1) {
+      if (sIndex > -1 && dsg_->getDataSize(sIndex) > 0) {
         auto sPointer = dsg_->getData(sIndex);
         subspaceIndices = getFGPointsOfSubspace(level);
         for (const auto& fIndex : subspaceIndices) {
@@ -1203,8 +1203,8 @@ class DistributedFullGrid {
    * @param dsg the DSG to extract from
    */
   void extractFromUniformSG(DistributedSparseGridUniform<FG_ELEMENT>& dsg) {
-    // test if dsg has already been registered
-    assert(dsg_ == &dsg);
+    // // test if dsg has already been registered
+    // assert(dsg_ == &dsg);
     assert(dsg.isSubspaceDataCreated());
 
     // all the hierarchical subspaces contained in this full grid
@@ -1215,7 +1215,7 @@ class DistributedFullGrid {
     static IndexVector subspaceIndices;
     for (const auto& level : downwardClosedSet) {
       sIndex = dsg_->getIndexInRange(level, sIndex);
-      if (sIndex > -1) {
+      if (sIndex > -1 && dsg_->getDataSize(sIndex) > 0) {
         auto sPointer = dsg_->getData(sIndex);
         subspaceIndices = getFGPointsOfSubspace(level);
         for (const auto& fIndex : subspaceIndices) {

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/manager/ProcessGroupWorker.cpp
@@ -568,7 +568,7 @@ void registerAllSubspacesInDSGU(DistributedSparseGridUniform<CombiDataType>& dsg
           new DistributedFullGrid<CombiDataType>(
               combiParameters.getDim(), level, dsgu.getCommunicator(), boundary,
               combiParameters.getParallelization(), false, dfgDecomposition));
-      uniDFG->registerUniformSG(dsgu);
+      dsgu.registerDistributedFullGrid(*uniDFG);
     } else {
       assert(levelSum(level) < highestLevelSum);
     }
@@ -633,8 +633,8 @@ void ProcessGroupWorker::initCombinedUniDSGVector() {
       MASTER_EXCLUSIVE_SECTION { std::cout << "register task " << t->getID() << std::endl; }
 #endif  // def DEBUG_OUTPUT
       DistributedFullGrid<CombiDataType>& dfg = t->getDistributedFullGrid(static_cast<int>(g));
-      // set subspace sizes local
-      dfg.registerUniformSG(*(combinedUniDSGVector_[g]));
+      // set subspace sizes locally
+      combinedUniDSGVector_[g]->registerDistributedFullGrid(dfg);
     }
   }
   Stats::stopEvent("register dsgus");
@@ -690,7 +690,7 @@ void ProcessGroupWorker::addFullGridsToUniformSG() {
       DistributedFullGrid<CombiDataType>& dfg = t->getDistributedFullGrid(static_cast<int>(g));
 
       // lokales reduce auf sg ->
-      dfg.addToUniformSG(*combinedUniDSGVector_[g], combiParameters_.getCoeff(t->getID()));
+      combinedUniDSGVector_[g]->addDistributedFullGrid(dfg, combiParameters_.getCoeff(t->getID()));
 #ifdef DEBUG_OUTPUT
       std::cout << "Combination: added task " << t->getID() << " with coefficient "
                 << combiParameters_.getCoeff(t->getID()) << "\n";

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
@@ -473,7 +473,7 @@ void DistributedSparseGridUniform<FG_ELEMENT>::setDataSize(SubspaceIndexType i, 
 template <typename FG_ELEMENT>
 inline void DistributedSparseGridUniform<FG_ELEMENT>::registerDistributedFullGrid(
     const DistributedFullGrid<FG_ELEMENT>& dfg) {
-  assert(dfg.getDim() == dim_);
+  assert(dfg.getDimension() == dim_);
   // all the hierarchical subspaces contained in the full grid
   const auto downwardClosedSet = combigrid::getDownSet(dfg.getLevels());
 
@@ -495,7 +495,7 @@ inline void DistributedSparseGridUniform<FG_ELEMENT>::registerDistributedFullGri
         ASSERT(subSgDataSize == numPointsOfSubspace,
                "subSgDataSize: " << subSgDataSize
                                  << ", numPointsOfSubspace: " << numPointsOfSubspace << " , level "
-                                 << level << " , rank " << this->getMpiRank() << std::endl);
+                                 << level << " , rank " << this->rank_ << std::endl);
       }
     }
   }

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
@@ -431,13 +431,17 @@ size_t DistributedSparseGridUniform<FG_ELEMENT>::getDataSize(SubspaceIndexType i
 template <typename FG_ELEMENT>
 void DistributedSparseGridUniform<FG_ELEMENT>::setDataSize(SubspaceIndexType i, size_t newSize) {
 #ifndef NDEBUG
+  assert(subspacesDataSizes_[i] == 0 || subspacesDataSizes_[i] == newSize);
   if (i >= getNumSubspaces()) {
     std::cout << "Index too large, no subspace with this index included in distributed sparse grid"
               << std::endl;
     assert(false);
   }
 #endif  // NDEBUG
-
+  if (newSize != subspacesDataSizes_[i]) {
+    // invalidate the data vector
+    this->deleteSubspaceData();
+  }
   subspacesDataSizes_[i] = newSize;
 }
 

--- a/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
+++ b/distributedcombigrid/src/sgpp/distributedcombigrid/sparsegrid/DistributedSparseGridUniform.hpp
@@ -486,6 +486,7 @@ void DistributedSparseGridUniform<FG_ELEMENT>::reduceSubspaceSizes(CommunicatorT
 template <typename FG_ELEMENT>
 inline void DistributedSparseGridUniform<FG_ELEMENT>::writeMinMaxCoefficents(
     const std::string& filename, size_t outputIndex) const {
+  assert(this->isSubspaceDataCreated());
   bool writerProcess = false;
   std::ofstream ofs;
   if (this->rank_ == 0) {
@@ -515,7 +516,7 @@ inline void DistributedSparseGridUniform<FG_ELEMENT>::writeMinMaxCoefficents(
       it = std::max_element(first, last, smaller_real);
       maximumValue = std::real(*it);
     }
-    // allreduce the minimum and maxiumum values
+    // allreduce the minimum and maximum values
     MPI_Allreduce(MPI_IN_PLACE, &minimumValue, 1, dataType, MPI_MIN, getCommunicator());
     MPI_Allreduce(MPI_IN_PLACE, &maximumValue, 1, dataType, MPI_MAX, getCommunicator());
 

--- a/distributedcombigrid/tests/test_distributedfullgrid.cpp
+++ b/distributedcombigrid/tests/test_distributedfullgrid.cpp
@@ -178,19 +178,19 @@ void checkDistributedFullgrid(LevelVector& levels, std::vector<int>& procs,
   }
   BOOST_TEST_CHECKPOINT("set function values");
 
-  // test addToUniformSG, extractFromUniformSG
+  // test addDistributedFullGrid, extractFromUniformSG
   LevelVector lmin = levels;
   LevelVector lmax = levels;
   for (DimType d = 0; d < dim; ++d) {
     lmax[d] *= 2;
   }
   DistributedSparseGridUniform<std::complex<double>> dsg(dim, lmax, lmin, comm);
-  dfg.registerUniformSG(dsg);
+  dsg.registerDistributedFullGrid(dfg);
   BOOST_TEST_CHECKPOINT("register uniform sg");
   DistributedFullGrid<std::complex<double>> dfg2(dim, levels, comm, boundary, procs, forward);
-  dfg2.registerUniformSG(dsg);
+  dsg.registerDistributedFullGrid(dfg2);
   dsg.setZero();
-  dfg.addToUniformSG(dsg, 2.1);
+  dsg.addDistributedFullGrid(dfg, 2.1);
   BOOST_TEST_CHECKPOINT("add to uniform sg");
   dfg2.extractFromUniformSG(dsg);
   BOOST_TEST_CHECKPOINT("extract from uniform sg");
@@ -1105,7 +1105,7 @@ BOOST_AUTO_TEST_CASE(test_registerUniformSG) {
 
     MPI_Barrier(comm);
     start = std::chrono::high_resolution_clock::now();
-    dfg.registerUniformSG(dsg);
+    dsg.registerDistributedFullGrid(dfg);
     end = std::chrono::high_resolution_clock::now();
     duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     BOOST_TEST_MESSAGE("time to register sparse grid: " << duration.count() << " milliseconds");
@@ -1115,7 +1115,7 @@ BOOST_AUTO_TEST_CASE(test_registerUniformSG) {
 
     MPI_Barrier(comm);
     start = std::chrono::high_resolution_clock::now();
-    otherDfg.registerUniformSG(dsg);
+    dsg.registerDistributedFullGrid(otherDfg);
     end = std::chrono::high_resolution_clock::now();
     duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     BOOST_TEST_MESSAGE("time to register sparse grid again: " << duration.count()
@@ -1138,7 +1138,7 @@ BOOST_AUTO_TEST_CASE(test_registerUniformSG) {
 
     MPI_Barrier(comm);
     start = std::chrono::high_resolution_clock::now();
-    dfg.addToUniformSG(dsg, 1.);
+    dsg.addDistributedFullGrid(dfg, 1.);
     end = std::chrono::high_resolution_clock::now();
     duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     BOOST_TEST_MESSAGE("time to add to sparse grid: " << duration.count() << " milliseconds");
@@ -1148,7 +1148,7 @@ BOOST_AUTO_TEST_CASE(test_registerUniformSG) {
 
     MPI_Barrier(comm);
     start = std::chrono::high_resolution_clock::now();
-    otherDfg.addToUniformSG(dsg, 1.);
+    dsg.addDistributedFullGrid(otherDfg, 1.);
     end = std::chrono::high_resolution_clock::now();
     duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     BOOST_TEST_MESSAGE("time to add to sparse grid again: " << duration.count() << " milliseconds");

--- a/distributedcombigrid/tests/test_distributedfullgrid.cpp
+++ b/distributedcombigrid/tests/test_distributedfullgrid.cpp
@@ -187,10 +187,11 @@ void checkDistributedFullgrid(LevelVector& levels, std::vector<int>& procs,
   DistributedSparseGridUniform<std::complex<double>> dsg(dim, lmax, lmin, comm);
   dfg.registerUniformSG(dsg);
   BOOST_TEST_CHECKPOINT("register uniform sg");
-  dfg.addToUniformSG(dsg, 2.1);
-  BOOST_TEST_CHECKPOINT("add to uniform sg");
   DistributedFullGrid<std::complex<double>> dfg2(dim, levels, comm, boundary, procs, forward);
   dfg2.registerUniformSG(dsg);
+  dsg.createSubspaceData();
+  dfg.addToUniformSG(dsg, 2.1);
+  BOOST_TEST_CHECKPOINT("add to uniform sg");
   dfg2.extractFromUniformSG(dsg);
   BOOST_TEST_CHECKPOINT("extract from uniform sg");
 

--- a/distributedcombigrid/tests/test_distributedfullgrid.cpp
+++ b/distributedcombigrid/tests/test_distributedfullgrid.cpp
@@ -189,7 +189,7 @@ void checkDistributedFullgrid(LevelVector& levels, std::vector<int>& procs,
   BOOST_TEST_CHECKPOINT("register uniform sg");
   DistributedFullGrid<std::complex<double>> dfg2(dim, levels, comm, boundary, procs, forward);
   dfg2.registerUniformSG(dsg);
-  dsg.createSubspaceData();
+  dsg.setZero();
   dfg.addToUniformSG(dsg, 2.1);
   BOOST_TEST_CHECKPOINT("add to uniform sg");
   dfg2.extractFromUniformSG(dsg);

--- a/distributedcombigrid/tests/test_distributedfullgrid.cpp
+++ b/distributedcombigrid/tests/test_distributedfullgrid.cpp
@@ -1076,6 +1076,7 @@ BOOST_AUTO_TEST_CASE(test_registerUniformSG) {
 #ifdef NDEBUG
     BOOST_CHECK(duration.count() < 2500);
 #endif
+    // go to the other extreme anisotropy by reversing the level vector
     std::reverse(fullGridLevel.begin(), fullGridLevel.end());
     std::reverse(boundary.begin(), boundary.end());
     decomposition[0] = {0, 1, 2, 3, 4};
@@ -1130,6 +1131,47 @@ BOOST_AUTO_TEST_CASE(test_registerUniformSG) {
     end = std::chrono::high_resolution_clock::now();
     duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     BOOST_TEST_MESSAGE("time to create sparse grid data: " << duration.count() << " milliseconds");
+#ifdef NDEBUG
+    BOOST_CHECK(duration.count() < 15000);
+#endif
+
+    MPI_Barrier(comm);
+    start = std::chrono::high_resolution_clock::now();
+    dfg.addToUniformSG(dsg, 1.);
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    BOOST_TEST_MESSAGE("time to add to sparse grid: " << duration.count() << " milliseconds");
+#ifdef NDEBUG
+    BOOST_CHECK(duration.count() < 15000);
+#endif
+
+    MPI_Barrier(comm);
+    start = std::chrono::high_resolution_clock::now();
+    otherDfg.addToUniformSG(dsg, 1.);
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    BOOST_TEST_MESSAGE("time to add to sparse grid again: " << duration.count() << " milliseconds");
+#ifdef NDEBUG
+    BOOST_CHECK(duration.count() < 15000);
+#endif
+
+    MPI_Barrier(comm);
+    start = std::chrono::high_resolution_clock::now();
+    dfg.extractFromUniformSG(dsg);
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    BOOST_TEST_MESSAGE("time to extract from sparse grid: " << duration.count() << " milliseconds");
+#ifdef NDEBUG
+    BOOST_CHECK(duration.count() < 15000);
+#endif
+
+    MPI_Barrier(comm);
+    start = std::chrono::high_resolution_clock::now();
+    otherDfg.extractFromUniformSG(dsg);
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    BOOST_TEST_MESSAGE("time to extract from sparse grid again: " << duration.count()
+                                                                  << " milliseconds");
 #ifdef NDEBUG
     BOOST_CHECK(duration.count() < 15000);
 #endif

--- a/distributedcombigrid/tests/test_distributedsparsegrid.cpp
+++ b/distributedcombigrid/tests/test_distributedsparsegrid.cpp
@@ -111,7 +111,7 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
         new DistributedFullGrid<std::complex<double>>(dim, dfgLevel, comm, boundary, procs, true,
                                                       dfgDecomposition));
 
-    uniDFG->registerUniformSG(*uniDSG);
+    uniDSG->registerDistributedFullGrid(*uniDFG);
 
     for (decltype(uniDSG->getNumSubspaces()) i = 0; i < uniDSG->getNumSubspaces(); ++i) {
       const auto& level = uniDSG->getLevelVector(i);
@@ -143,14 +143,14 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
     BOOST_TEST_CHECKPOINT("Add to uniform SG");
     // create subspace data
     uniDSG->setZero();
-    uniDFG->addToUniformSG(*uniDSG, 1.);
+    uniDSG->addDistributedFullGrid(*uniDFG, 1.);
 
     BOOST_TEST_CHECKPOINT("Add to uniform SG from subspaces");
-    uniDFG->registerUniformSG(*uniDSGfromSubspaces);
+    uniDSGfromSubspaces->registerDistributedFullGrid(*uniDFG);
     BOOST_CHECK_EQUAL(0, uniDSGfromSubspaces->getRawDataSize());
     BOOST_CHECK_GT(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
     uniDSGfromSubspaces->setZero();
-    uniDFG->addToUniformSG(*uniDSGfromSubspaces, 0.);
+    uniDSGfromSubspaces->addDistributedFullGrid(*uniDFG, 0.);
     BOOST_CHECK_EQUAL(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
     for (decltype(uniDSGfromSubspaces->getNumSubspaces()) i = 0;
          i < uniDSGfromSubspaces->getNumSubspaces(); ++i) {
@@ -221,7 +221,7 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
     }
 
     BOOST_TEST_CHECKPOINT("Register to uniform SG");
-    largeUniDFG->registerUniformSG(*uniDSG); //TODO create levels and actually test something
+    uniDSG->registerDistributedFullGrid(*largeUniDFG);//TODO create levels and actually test something
 
     // // make sure that right min/max values are written %TODO remove file
     // BOOST_TEST_CHECKPOINT("write min/max coefficients");
@@ -657,7 +657,7 @@ BOOST_AUTO_TEST_CASE(test_writeOneFileToDisk) {
         auto uniDFG = std::unique_ptr<DistributedFullGrid<combigrid::real>>(
             new DistributedFullGrid<combigrid::real>(dim, level, comm, boundary, procs, true,
                                                      dfgDecomposition));
-        uniDFG->registerUniformSG(*uniDSG);
+        uniDSG->registerDistributedFullGrid(*uniDFG);
       }
     }
     uniDSG->setZero();

--- a/distributedcombigrid/tests/test_distributedsparsegrid.cpp
+++ b/distributedcombigrid/tests/test_distributedsparsegrid.cpp
@@ -112,8 +112,6 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
                                                       dfgDecomposition));
 
     uniDFG->registerUniformSG(*uniDSG);
-    uniDFG->registerUniformSG(*uniDSGfromSubspaces);
-    BOOST_CHECK_EQUAL(0, uniDSGfromSubspaces->getRawDataSize());
 
     for (decltype(uniDSG->getNumSubspaces()) i = 0; i < uniDSG->getNumSubspaces(); ++i) {
       const auto& level = uniDSG->getLevelVector(i);
@@ -146,6 +144,10 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
     // create subspace data
     uniDSG->createSubspaceData();
     uniDFG->addToUniformSG(*uniDSG, 1.);
+
+    BOOST_TEST_CHECKPOINT("Add to uniform SG from subspaces");
+    uniDFG->registerUniformSG(*uniDSGfromSubspaces);
+    BOOST_CHECK_EQUAL(0, uniDSGfromSubspaces->getRawDataSize());
     BOOST_CHECK_GT(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
     uniDSGfromSubspaces->createSubspaceData();
     uniDFG->addToUniformSG(*uniDSGfromSubspaces, 0.);
@@ -202,7 +204,7 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
                                                       dfgDecomposition));
 
     BOOST_TEST_CHECKPOINT("Register to uniform SG");
-    largeUniDFG->registerUniformSG(*uniDSG);
+    largeUniDFG->registerUniformSG(*uniDSG); //TODO create levels and actually test something
 
     // make sure that right min/max values are written %TODO remove file
     BOOST_TEST_CHECKPOINT("write min/max coefficients");

--- a/distributedcombigrid/tests/test_distributedsparsegrid.cpp
+++ b/distributedcombigrid/tests/test_distributedsparsegrid.cpp
@@ -143,8 +143,11 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
     // hierarchical space (without interpolation on coarser component dfgs) here we use the nodal
     // values for testing purposes
     BOOST_TEST_CHECKPOINT("Add to uniform SG");
+    // create subspace data
+    uniDSG->createSubspaceData();
     uniDFG->addToUniformSG(*uniDSG, 1.);
     BOOST_CHECK_GT(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
+    uniDSGfromSubspaces->createSubspaceData();
     uniDFG->addToUniformSG(*uniDSGfromSubspaces, 0.);
     BOOST_CHECK_EQUAL(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
     for (decltype(uniDSGfromSubspaces->getNumSubspaces()) i = 0;

--- a/distributedcombigrid/tests/test_distributedsparsegrid.cpp
+++ b/distributedcombigrid/tests/test_distributedsparsegrid.cpp
@@ -142,14 +142,14 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
     // values for testing purposes
     BOOST_TEST_CHECKPOINT("Add to uniform SG");
     // create subspace data
-    uniDSG->createSubspaceData();
+    uniDSG->setZero();
     uniDFG->addToUniformSG(*uniDSG, 1.);
 
     BOOST_TEST_CHECKPOINT("Add to uniform SG from subspaces");
     uniDFG->registerUniformSG(*uniDSGfromSubspaces);
     BOOST_CHECK_EQUAL(0, uniDSGfromSubspaces->getRawDataSize());
     BOOST_CHECK_GT(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
-    uniDSGfromSubspaces->createSubspaceData();
+    uniDSGfromSubspaces->setZero();
     uniDFG->addToUniformSG(*uniDSGfromSubspaces, 0.);
     BOOST_CHECK_EQUAL(uniDSG->getRawDataSize(), uniDSGfromSubspaces->getRawDataSize());
     for (decltype(uniDSGfromSubspaces->getNumSubspaces()) i = 0;
@@ -203,13 +203,30 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
         new DistributedFullGrid<std::complex<double>>(dim, dfgLevel, comm, boundary, procs, true,
                                                       dfgDecomposition));
 
+
+    // test for dumping sparse grid data to disk and reading back in
+    uniDSG->writeToDiskChunked("test_sg_");
+    uniDSGfromSubspaces->setZero();
+    uniDSGfromSubspaces->readFromDiskChunked("test_sg_");
+    BOOST_TEST_CHECKPOINT("compare values chunked");
+    for (size_t i = 0; i < uniDSG->getRawDataSize(); ++i) {
+      BOOST_TEST_CONTEXT(std::to_string(i));
+      BOOST_CHECK_EQUAL(uniDSG->getRawData()[i], uniDSGfromSubspaces->getRawData()[i]);
+    }
+
+    // and remove straight away
+    if (rank == 0) {
+      auto status = system("rm test_sg_*");
+      BOOST_CHECK_GE(status, 0);
+    }
+
     BOOST_TEST_CHECKPOINT("Register to uniform SG");
     largeUniDFG->registerUniformSG(*uniDSG); //TODO create levels and actually test something
 
-    // make sure that right min/max values are written %TODO remove file
-    BOOST_TEST_CHECKPOINT("write min/max coefficients");
-    uniDSG->writeMinMaxCoefficents(
-        "sparse_paraboloid_minmax_large_" + std::to_string(dim) + "D_" + std::to_string(size), 0);
+    // // make sure that right min/max values are written %TODO remove file
+    // BOOST_TEST_CHECKPOINT("write min/max coefficients");
+    // uniDSG->writeMinMaxCoefficents(
+    //     "sparse_paraboloid_minmax_large_" + std::to_string(dim) + "D_" + std::to_string(size), 0);
 
     // check if the sizes set are actually the ones we calculate with CombiMinMaxScheme
     BOOST_TEST_CHECKPOINT("check subspace sizes");
@@ -250,21 +267,6 @@ void checkDistributedSparsegrid(LevelVector& lmin, LevelVector& lmax, std::vecto
         auto sgDOF = printSGDegreesOfFreedomAdaptive(newLmin, newLmax);
         BOOST_CHECK_EQUAL(sgDOF, sumDOFPartitioned);
       }
-    }
-    // test for dumping sparse grid data to disk and reading back in
-    uniDSG->writeToDiskChunked("test_sg_");
-    uniDSGfromSubspaces->setZero();
-    uniDSGfromSubspaces->readFromDiskChunked("test_sg_");
-    BOOST_TEST_CHECKPOINT("compare values chunked");
-    for (size_t i = 0; i < uniDSG->getRawDataSize(); ++i) {
-      BOOST_TEST_CONTEXT(std::to_string(i));
-      BOOST_CHECK_EQUAL(uniDSG->getRawData()[i], uniDSGfromSubspaces->getRawData()[i]);
-    }
-
-    // and remove straight away
-    if (rank == 0) {
-      auto status = system("rm test_sg_*");
-      BOOST_CHECK_GE(status, 0);
     }
   }
 }

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -207,15 +207,15 @@ real checkConservationOfMomentum(DistributedFullGrid<FG_ELEMENT>& dfg,
   LevelVector lone(dim, 1);  // cannot use lmin 0 in dsgu's constructor
   auto uniDSG = std::unique_ptr<DistributedSparseGridUniform<FG_ELEMENT>>(
       new DistributedSparseGridUniform<FG_ELEMENT>(dim, dfg.getLevels(), lone, comm));
-  dfg.registerUniformSG(*uniDSG);
+  uniDSG->registerDistributedFullGrid(dfg);
   // TODO also cannot use level 0 to register dfg -- problem!
   auto dfgOne = std::unique_ptr<DistributedFullGrid<FG_ELEMENT>>(
       new DistributedFullGrid<FG_ELEMENT>(dim, lone, comm, boundary, procs));
-  dfgOne->registerUniformSG(*uniDSG);
+  uniDSG->registerDistributedFullGrid(*dfgOne);
   uniDSG->setZero();
   BOOST_TEST_CHECKPOINT("registered sparse grid");
 
-  dfg.addToUniformSG(*uniDSG, 1.);
+  uniDSG->addDistributedFullGrid(dfg, 1.);
   dfgOne->extractFromUniformSG(*uniDSG);
 
   // TODO extract boundary grid lvl 1 to lvl 0 for now

--- a/distributedcombigrid/tests/test_hierarchization.cpp
+++ b/distributedcombigrid/tests/test_hierarchization.cpp
@@ -212,6 +212,7 @@ real checkConservationOfMomentum(DistributedFullGrid<FG_ELEMENT>& dfg,
   auto dfgOne = std::unique_ptr<DistributedFullGrid<FG_ELEMENT>>(
       new DistributedFullGrid<FG_ELEMENT>(dim, lone, comm, boundary, procs));
   dfgOne->registerUniformSG(*uniDSG);
+  uniDSG->setZero();
   BOOST_TEST_CHECKPOINT("registered sparse grid");
 
   dfg.addToUniformSG(*uniDSG, 1.);


### PR DESCRIPTION
This PR has two things:

first, we don't store the connection between the sparse and full grid DOF any more but compute them ad hoc. for the timings in test_registerUniformSG, this means that the time to register is almost zero now (because no vectors are stored), but the timings for adding and extracting are higher (approx. 0.7-2s on ipvs-epyc1).

second, the register and add functions are moved from the class DistributedFullGrid to DistributedSparseGridUniform, to make more explicit which structure is and isn't changed.

also, some of the tests were not doing what one would expect, which I have changed.
