### PR TITLE
Use boost::numeric::ublas::tensor as underlying data structure for DistributedFullGrid

### DIFF
--- a/examples/combi_example/TaskExample.hpp
+++ b/examples/combi_example/TaskExample.hpp
@@ -87,7 +87,7 @@ class TaskExample : public Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(dim, l, lcomm, this->getBoundary(), p);
 
     /* loop over local subgrid and set initial values */
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
 
     for (size_t i = 0; i < elements.size(); ++i) {
       IndexType globalLinearIndex = dfg_->getGlobalLinearIndex(i);
@@ -109,7 +109,7 @@ class TaskExample : public Task {
 
     int lrank = theMPISystem()->getLocalRank();
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     // TODO if your Example uses another data structure, you need to copy
     // the data from elements to that data structure
 

--- a/examples/combi_example_faults/TaskExample.hpp
+++ b/examples/combi_example_faults/TaskExample.hpp
@@ -91,7 +91,7 @@ class TaskExample: public Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(dim, l, lcomm, this->getBoundary(), p);
 
     /* loop over local subgrid and set initial values */
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
 
     for (size_t i = 0; i < elements.size(); ++i) {
       IndexType globalLinearIndex = dfg_->getGlobalLinearIndex(i);
@@ -115,7 +115,7 @@ class TaskExample: public Task {
 
     /* pseudo timestepping to demonstrate the behaviour of your typical
      * time-dependent simulation problem. */
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
 
     for (size_t step = stepsTotal_; step < stepsTotal_ + nsteps_; ++step) {
       real time = (step + 1)* dt_;

--- a/examples/distributed_advection/TaskAdvection.hpp
+++ b/examples/distributed_advection/TaskAdvection.hpp
@@ -30,8 +30,8 @@ class TaskAdvection : public Task {
   /* if the constructor of the base task class is not sufficient we can provide an
    * own implementation. here, we add dt, nsteps, and p as a new parameters.
    */
-  TaskAdvection(DimType dim, const LevelVector& l, const std::vector<BoundaryType>& boundary,
-                real coeff, LoadModel* loadModel, real dt, size_t nsteps,
+  TaskAdvection(const LevelVector& l, const std::vector<BoundaryType>& boundary, real coeff,
+                LoadModel* loadModel, real dt, size_t nsteps,
                 std::vector<int> p = std::vector<int>(0),
                 FaultCriterion* faultCrit = (new StaticFaults({0, IndexVector(0), IndexVector(0)})))
       : Task(l, boundary, coeff, loadModel, faultCrit),

--- a/examples/distributed_advection/combi_example.cpp
+++ b/examples/distributed_advection/combi_example.cpp
@@ -178,7 +178,7 @@ int main(int argc, char** argv) {
     TaskContainer tasks;
     std::vector<size_t> taskIDs;
     for (size_t i = 0; i < levels.size(); i++) {
-      Task* t = new TaskAdvection(dim, levels[i], boundary, coeffs[i], loadmodel.get(), dt,
+      Task* t = new TaskAdvection(levels[i], boundary, coeffs[i], loadmodel.get(), dt,
                                   nsteps, p);
 
       static_assert(!isGENE, "isGENE");

--- a/examples/distributed_third_level/TaskAdvection.hpp
+++ b/examples/distributed_third_level/TaskAdvection.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+
 #include "fullgrid/DistributedFullGrid.hpp"
 #include "task/Task.hpp"
-
 namespace combigrid {
 
 // exact solution
@@ -21,8 +21,9 @@ class TestFn {
     // leave out normalization, such that maximum is always 1
     return std::exp(exponent);  // / std::sqrt( std::pow(2*pi*sigmaSquared, coords.size()));
   }
+
  private:
-  static constexpr double sigmaSquaredInv_ = 1. / ((1./3.)*(1./3.));
+  static constexpr double sigmaSquaredInv_ = 1. / ((1. / 3.) * (1. / 3.));
 };
 
 class TaskAdvection : public Task {
@@ -30,8 +31,8 @@ class TaskAdvection : public Task {
   /* if the constructor of the base task class is not sufficient we can provide an
    * own implementation. here, we add dt, nsteps, and p as a new parameters.
    */
-  TaskAdvection(const LevelVector& l, const std::vector<BoundaryType>& boundary,
-                real coeff, LoadModel* loadModel, real dt, size_t nsteps,
+  TaskAdvection(const LevelVector& l, const std::vector<BoundaryType>& boundary, real coeff,
+                LoadModel* loadModel, real dt, size_t nsteps,
                 std::vector<int> p = std::vector<int>(0),
                 FaultCriterion* faultCrit = (new StaticFaults({0, IndexVector(0), IndexVector(0)})))
       : Task(l, boundary, coeff, loadModel, faultCrit),
@@ -59,7 +60,7 @@ class TaskAdvection : public Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(dim, l, lcomm, this->getBoundary(), p_, false,
                                                   decomposition);
     if (phi_ == nullptr) {
-      phi_ = new std::vector<CombiDataType>(dfg_->getNrLocalElements());
+      phi_ = new DistributedFullGrid<CombiDataType>::TensorType(dfg_->getLocalExtents());
     }
 
     std::vector<double> h = dfg_->getGridSpacing();
@@ -95,8 +96,7 @@ class TaskAdvection : public Task {
     std::vector<double> h = dfg_->getGridSpacing();
     const auto& fullOffsets = dfg_->getLocalOffsets();
 
-    phi_->resize(dfg_->getNrLocalElements());
-    std::fill(phi_->begin(), phi_->end(), 0.);
+    phi_->reshape(dfg_->getLocalExtents(), 0.);
 
     for (size_t i = 0; i < nsteps_; ++i) {
       // compute the gradient in the original dfg_, then update into phi_ and
@@ -122,7 +122,7 @@ class TaskAdvection : public Task {
           dfg_->getLocalVectorIndex(li, locAxisIndex);
           // TODO can be unrolled into ghost and other part, avoiding if-statement
           CombiDataType phi_neighbor = 0.;
-          if (locAxisIndex[d] == 0){
+          if (locAxisIndex[d] == 0) {
             assert(phi_ghost.size() > 0);
             // then use values from boundary exchange
             IndexType gli = 0;
@@ -132,10 +132,7 @@ class TaskAdvection : public Task {
             assert(gli > -1);
             assert(gli < phi_ghost.size());
             phi_neighbor = phi_ghost[gli];
-          } else{
-            // --locAxisIndex[d];
-            // IndexType lni = dfg_->getLocalLinearIndex(locAxisIndex);
-            // assert(lni == (li - fullOffsets[d]));
+          } else {
             phi_neighbor = dfg_->getElementVector()[li - fullOffsets[d]];
           }
           // calculate gradient of phi with backward differential quotient
@@ -144,10 +141,11 @@ class TaskAdvection : public Task {
           u_dot_dphi[li] += velocity[d] * dphi;
         }
       }
+      // update all values in phi_
       for (IndexType li = 0; li < dfg_->getNrLocalElements(); ++li) {
         (*phi_)[li] = dfg_->getElementVector()[li] - u_dot_dphi[li] * dt_;
       }
-      phi_->swap(dfg_->getElementVector());
+      std::swap(*phi_, dfg_->getElementVector());
     }
     stepsTotal_ += nsteps_;
 
@@ -161,7 +159,8 @@ class TaskAdvection : public Task {
    * solution on one process and then converting it to the full grid representation.
    * the DistributedFullGrid class offers a convenient function to do this.
    */
-  void getFullGrid(FullGrid<CombiDataType>& fg, RankType r, CommunicatorType lcomm, int n = 0) override {
+  void getFullGrid(FullGrid<CombiDataType>& fg, RankType r, CommunicatorType lcomm,
+                   int n = 0) override {
     assert(fg.getLevels() == dfg_->getLevels());
 
     dfg_->gatherFullGrid(fg, r);
@@ -181,15 +180,13 @@ class TaskAdvection : public Task {
     phi_ = nullptr;
   }
 
-  real getCurrentTime() const override {
-    return stepsTotal_ * dt_;
-  }
+  real getCurrentTime() const override { return stepsTotal_ * dt_; }
 
   CombiDataType analyticalSolution(const std::vector<real>& coords, int n = 0) const override {
     assert(n == 0);
     auto coordsCopy = coords;
     TestFn f;
-    return f(coordsCopy, stepsTotal_*dt_);
+    return f(coordsCopy, stepsTotal_ * dt_);
   }
 
  protected:
@@ -212,7 +209,7 @@ class TaskAdvection : public Task {
   bool initialized_;
   size_t stepsTotal_;
   DistributedFullGrid<CombiDataType>* dfg_;
-  static std::vector<CombiDataType>* phi_;
+  static typename DistributedFullGrid<CombiDataType>::TensorType* phi_;
 
   /**
    * The serialize function has to be extended by the new member variables.
@@ -234,6 +231,6 @@ class TaskAdvection : public Task {
   }
 };
 
-std::vector<CombiDataType>* TaskAdvection::phi_ = nullptr;
+typename DistributedFullGrid<CombiDataType>::TensorType* TaskAdvection::phi_ = nullptr;
 
 }  // namespace combigrid

--- a/examples/distributed_third_level/TaskConst.hpp
+++ b/examples/distributed_third_level/TaskConst.hpp
@@ -38,7 +38,7 @@ class TaskConst : public combigrid::Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(),
                                                   p, false, decomposition);
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = 10;
     }
@@ -49,7 +49,7 @@ class TaskConst : public combigrid::Task {
 
     // std::cout << "run " << getCommRank(lcomm) << std::endl;    
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = getLevelVector()[0] / (double)getLevelVector()[1];
       // std::cout << "e " << element << std::endl;

--- a/examples/selalib_distributed/src/SelalibTask.hpp
+++ b/examples/selalib_distributed/src/SelalibTask.hpp
@@ -299,7 +299,7 @@ class SelalibTask : public combigrid::Task {
 
   void setDFGfromLocalDistribution() {
 #ifndef NDEBUG
-    auto& localDFGSize = dfg_->getLocalSizes();
+    auto& localDFGSize = dfg_->getLocalExtents();
     assert(dim_ == 6);
     // std::cout << localDFGSize << " " << std::vector<int>(localSize_.begin(), localSize_.end()) <<
     // std::endl;

--- a/src/fullgrid/MultiArray.hpp
+++ b/src/fullgrid/MultiArray.hpp
@@ -16,7 +16,7 @@ using MultiArrayRef = boost::multi_array_ref<T, D>;
 template <typename T, size_t D>
 static MultiArrayRef<T, D> createMultiArrayRef(DistributedFullGrid<T>& dfg) {
   /* note that the sizes of dfg are in reverse order compared to shape */
-  std::vector<size_t> shape(dfg.getLocalSizes().rbegin(), dfg.getLocalSizes().rend());
+  std::vector<size_t> shape(dfg.getLocalExtents().rbegin(), dfg.getLocalExtents().rend());
   if (!reverseOrderingDFGPartitions) {
     assert(false && "this is not adapted to normal ordering of DFG partitions yet");
   }

--- a/src/fullgrid/SliceIterator.hpp
+++ b/src/fullgrid/SliceIterator.hpp
@@ -105,11 +105,11 @@ class SliceIterator {
   void setEndIndex() {
     std::vector<int> endVectorIndex = this->starts_;
     endVectorIndex[this->getDimension() - 1] += this - subsizes_[this->getDimension() - 1];
-    linEndIndex_ = linearize(endVectorIndex);
+    linearEndIndex_ = linearize(endVectorIndex);
   }
   IndexType endIndex() const {
-    assert(linEndIndex_ != -1);
-    return linEndIndex_;
+    assert(linearEndIndex_ != -1);
+    return linearEndIndex_;
   }
 
  protected:

--- a/src/fullgrid/SliceIterator.hpp
+++ b/src/fullgrid/SliceIterator.hpp
@@ -1,0 +1,144 @@
+#pragma once
+#include <cassert>
+
+#include "utils/IndexVector.hpp"
+#include "utils/Types.hpp"
+
+namespace combigrid {
+template <typename FG_ELEMENT>
+class SliceIterator {
+ public:
+  // cf. https://www.internalpointers.com/post/writing-custom-iterators-modern-cpp
+  using iterator_category = std::forward_iterator_tag;
+  using difference_type = std::ptrdiff_t;
+  using value_type = FG_ELEMENT;
+  using pointer = FG_ELEMENT*;
+  using reference = FG_ELEMENT&;
+
+  SliceIterator(const std::vector<int>& subsizes, const std::vector<int>& starts,
+                const IndexVector& offsets, std::vector<FG_ELEMENT>* dataPointer)
+      : currentLocalIndex_(starts),
+        subsizes_(subsizes),
+        starts_(starts),
+        offsets_(offsets),
+        dataPointer_(dataPointer) {
+    this->setEndIndex();
+    this->validateSizes();
+  }
+
+  // cheap rule of 5
+  explicit SliceIterator() = default;
+  SliceIterator(const SliceIterator& other) = delete;
+  SliceIterator& operator=(const SliceIterator&) = delete;
+  SliceIterator(SliceIterator&& other) = delete;
+  SliceIterator& operator=(SliceIterator&& other) = delete;
+
+  reference operator*() const {
+#ifndef NDEBUG
+    // make sure to only dereference when we actually have the data mapped
+    if (linearize(currentLocalIndex_) > dataPointer_->size()) {
+      std::cout << " subsizes " << subsizes_ << " starts " << starts_ << " end " << endIndex()
+                << std::endl;
+      std::cout << " ref waah currentLocalIndex_" << currentLocalIndex_ << " linearized "
+                << linearize(currentLocalIndex_) << " numElements " << dataPointer_->size()
+                << std::endl;
+    }
+    assert(linearize(currentLocalIndex_) <= dataPointer_->size());
+    assert(linearize(currentLocalIndex_) < endIndex());
+#endif  // ndef NDEBUG
+    return (*dataPointer_)[linearize(currentLocalIndex_)];
+  }
+
+  pointer operator->() const { return &((*dataPointer_)[linearize(currentLocalIndex_)]); }
+  pointer getPointer() const { return &((*dataPointer_)[linearize(currentLocalIndex_)]); }
+
+  const std::vector<int>& getVecIndex() const { return currentLocalIndex_; }
+  IndexType getIndex() const { return linearize(currentLocalIndex_); }
+
+  const SliceIterator& operator++() {
+#ifndef NDEBUG
+    assert(linearize(currentLocalIndex_) <= dataPointer_->size());
+    auto cpLocalIdx = currentLocalIndex_;
+    auto idxbefore = linearize(currentLocalIndex_);
+#endif  // ndef NDEBUG
+    // increment
+    // Fortran ordering
+    currentLocalIndex_[0] += 1;
+    for (DimType d = 0; d < this->getDimension() - 1; ++d) {
+      // wrap around
+#ifndef NDEBUG
+      if (currentLocalIndex_[d] > starts_[d] + subsizes_[d]) {
+        std::cout << " subsizes " << subsizes_ << " starts " << starts_ << " end " << endIndex()
+                  << " idxbefore " << idxbefore << std::endl;
+        std::cout << "waah currentLocalIndex_" << currentLocalIndex_ << " before " << cpLocalIdx
+                  << std::endl;
+      }
+      assert(currentLocalIndex_[d] >= starts_[d]);
+      assert(!(currentLocalIndex_[d] > starts_[d] + subsizes_[d]));
+#endif  // ndef NDEBUG
+      // expect that it is more likely that we do not have to wrap around
+      // if (__builtin_expect((currentLocalIndex_[d] == starts_[d] + subsizes_[d]), false)) {
+      // (not sure if this is always the case)
+      if (currentLocalIndex_[d] == starts_[d] + subsizes_[d]) {
+        currentLocalIndex_[d] = starts_[d];
+        ++currentLocalIndex_[d + 1];
+      }
+    }
+    assert(idxbefore < linearize(currentLocalIndex_));
+    assert(linearize(currentLocalIndex_) <= endIndex());
+    return *this;
+  }
+  friend bool operator==(const SliceIterator& a, const SliceIterator& b) {
+    return a.currentLocalIndex_ == b.currentLocalIndex_;
+  };
+  friend bool operator!=(const SliceIterator& a, const SliceIterator& b) {
+    return a.currentLocalIndex_ != b.currentLocalIndex_;
+  };
+  pointer begin() { return &((*dataPointer_)[firstIndex()]); }
+  pointer end() { return &((*dataPointer_)[endIndex()]); }
+  bool isAtEnd() const { return (linearize(currentLocalIndex_) == endIndex()); }
+  int size() const {
+    return std::accumulate(subsizes_.begin(), subsizes_.end(), 1, std::multiplies<int>());
+  }
+
+  IndexType firstIndex() const { return linearize(starts_); }
+  void setEndIndex() {
+    std::vector<int> endVectorIndex = this->starts_;
+    endVectorIndex[this->getDimension() - 1] += this - subsizes_[this->getDimension() - 1];
+    linEndIndex_ = linearize(endVectorIndex);
+  }
+  IndexType endIndex() const {
+    assert(linEndIndex_ != -1);
+    return linEndIndex_;
+  }
+
+ protected:
+  inline DimType getDimension() const { return static_cast<DimType>(subsizes_.size()); }
+
+  inline IndexType linearize(const std::vector<int>& indexVector) const {
+    IndexType index = 0;
+    // Fortran ordering
+    for (DimType d = 0; d < subsizes_.size(); ++d) {
+      index += offsets_[d] * indexVector[d];
+    }
+    return index;
+  }
+
+  void validateSizes() {
+    assert(offsets_[0] == 1);
+    assert(std::accumulate(this->subsizes_.begin(), this->subsizes_.end(), 1,
+                           std::multiplies<int>()) <= this->dataPointer_->size());
+    assert(linearize(this->currentLocalIndex_) <= this->dataPointer_->size());
+    assert(currentLocalIndex_.size() == this->getDimension());
+    assert(subsizes_.size() == this->getDimension());
+    assert(starts_.size() == this->getDimension());
+  }
+
+  std::vector<int> currentLocalIndex_;
+  std::vector<int> subsizes_;
+  std::vector<int> starts_;
+  IndexVector offsets_;
+  std::vector<FG_ELEMENT>* dataPointer_;
+  IndexType linearEndIndex_ = -1;
+};
+}  // namespace combigrid

--- a/src/fullgrid/SliceIterator.hpp
+++ b/src/fullgrid/SliceIterator.hpp
@@ -104,7 +104,7 @@ class SliceIterator {
   IndexType firstIndex() const { return linearize(starts_); }
   void setEndIndex() {
     std::vector<int> endVectorIndex = this->starts_;
-    endVectorIndex[this->getDimension() - 1] += this - subsizes_[this->getDimension() - 1];
+    endVectorIndex[this->getDimension() - 1] += this->subsizes_[this->getDimension() - 1];
     linearEndIndex_ = linearize(endVectorIndex);
   }
   IndexType endIndex() const {

--- a/src/hierarchization/DistributedHierarchization.hpp
+++ b/src/hierarchization/DistributedHierarchization.hpp
@@ -184,7 +184,7 @@ void sendAndReceiveIndices(const std::map<RankType, std::set<IndexType>>& send1d
       MPI_Datatype mysubarray;
       {
         // sizes of local grid
-        std::vector<int> sizes(dfg.getLocalSizes().begin(), dfg.getLocalSizes().end());
+        std::vector<int> sizes(dfg.getLocalExtents().begin(), dfg.getLocalExtents().end());
 
         // sizes of subarray ( full size except dimension d )
         std::vector<int> subsizes = sizes;
@@ -274,7 +274,7 @@ void sendAndReceiveIndicesBlock(const std::map<RankType, std::set<IndexType>>& s
   MPI_Datatype mysubarray;
   {
     // sizes of local grid
-    std::vector<int> sizes(dfg.getLocalSizes().begin(), dfg.getLocalSizes().end());
+    std::vector<int> sizes(dfg.getLocalExtents().begin(), dfg.getLocalExtents().end());
 
     // sizes of subarray ( full size except dimension d )
     std::vector<int> subsizes = sizes;
@@ -1036,7 +1036,7 @@ void hierarchizeWithBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   auto lmax = dfg.getLevels()[dim];
   auto size = dfg.getNrLocalElements();
   auto stride = dfg.getLocalOffsets()[dim];
-  auto ndim = dfg.getLocalSizes()[dim];
+  auto ndim = dfg.getLocalExtents()[dim];
   IndexType jump = stride * ndim;
   IndexType nbrOfPoles = size / ndim;
 
@@ -1050,7 +1050,7 @@ void hierarchizeWithBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   bool oneSidedBoundary = dfg.returnBoundaryFlags()[dim] == 1;
   tmp.resize(dfg.getGlobalSizes()[dim] + (oneSidedBoundary ? 1 : 0),
              std::numeric_limits<double>::quiet_NaN());
-  std::vector<FG_ELEMENT>& ldata = dfg.getElementVector();
+  auto& ldata = dfg.getElementVector();
   lldiv_t divresult;
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
@@ -1107,7 +1107,7 @@ void hierarchizeNoBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   LevelType lmax = dfg.getLevels()[dim];
   IndexType size = dfg.getNrLocalElements();
   IndexType stride = dfg.getLocalOffsets()[dim];
-  IndexType ndim = dfg.getLocalSizes()[dim];
+  IndexType ndim = dfg.getLocalExtents()[dim];
   IndexType jump = stride * ndim;
   IndexType nbrOfPoles = size / ndim;
 
@@ -1115,7 +1115,7 @@ void hierarchizeNoBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
 
   // loop over poles
   std::vector<FG_ELEMENT> tmp(dfg.getGlobalSizes()[dim], std::numeric_limits<double>::quiet_NaN());
-  std::vector<FG_ELEMENT>& ldata = dfg.getElementVector();
+  auto& ldata = dfg.getElementVector();
   lldiv_t divresult;
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
@@ -1190,7 +1190,7 @@ void dehierarchizeWithBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   const auto& lmax = dfg.getLevels()[dim];
   const auto& size = dfg.getNrLocalElements();
   const auto& stride = dfg.getLocalOffsets()[dim];
-  const auto& ndim = dfg.getLocalSizes()[dim];
+  const auto& ndim = dfg.getLocalExtents()[dim];
   IndexType jump = stride * ndim;
   IndexType nbrOfPoles = size / ndim;
 
@@ -1204,7 +1204,7 @@ void dehierarchizeWithBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   bool oneSidedBoundary = dfg.returnBoundaryFlags()[dim] == 1;
   tmp.resize(dfg.getGlobalSizes()[dim] + (oneSidedBoundary ? 1 : 0),
              std::numeric_limits<double>::quiet_NaN());
-  std::vector<FG_ELEMENT>& ldata = dfg.getElementVector();
+  auto& ldata = dfg.getElementVector();
   lldiv_t divresult;
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];
@@ -1257,7 +1257,7 @@ void dehierarchizeNoBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   auto lmax = dfg.getLevels()[dim];
   auto size = dfg.getNrLocalElements();
   auto stride = dfg.getLocalOffsets()[dim];
-  auto ndim = dfg.getLocalSizes()[dim];
+  auto ndim = dfg.getLocalExtents()[dim];
   IndexType jump = stride * ndim;
   IndexType nbrOfPoles = size / ndim;
 
@@ -1266,7 +1266,7 @@ void dehierarchizeNoBoundary(DistributedFullGrid<FG_ELEMENT>& dfg,
   // loop over poles
   static std::vector<FG_ELEMENT> tmp;
   tmp.resize(dfg.getGlobalSizes()[dim], std::numeric_limits<double>::quiet_NaN());
-  std::vector<FG_ELEMENT>& ldata = dfg.getElementVector();
+  auto& ldata = dfg.getElementVector();
   lldiv_t divresult;
   IndexType start;
   IndexType gstart = dfg.getLowerBounds()[dim];

--- a/tests/TaskConst.hpp
+++ b/tests/TaskConst.hpp
@@ -40,7 +40,7 @@ class TaskConst : public combigrid::Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(),
                                                   p, false, decomposition);
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = 10;
     }
@@ -51,7 +51,7 @@ class TaskConst : public combigrid::Task {
 
     // std::cout << "run " << getCommRank(lcomm) << std::endl;    
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = getLevelVector()[0] / (double)getLevelVector()[1];
       // std::cout << "e " << element << std::endl;

--- a/tests/TaskCount.hpp
+++ b/tests/TaskCount.hpp
@@ -49,7 +49,7 @@ class TaskCount : public combigrid::Task {
     }
     dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(), p, false, decomposition);
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = -0.;
     }

--- a/tests/test_distributedfullgrid.cpp
+++ b/tests/test_distributedfullgrid.cpp
@@ -169,8 +169,11 @@ void checkDistributedFullgrid(LevelVector& levels, std::vector<int>& procs,
   TestFn f;
   const auto dim = static_cast<DimType>(levels.size());
 
-  // create dfg
+  BOOST_TEST_CHECKPOINT("create dfg");
   DistributedFullGrid<std::complex<double>> dfg(dim, levels, comm, boundary, procs, forward);
+  BOOST_CHECK(dfg.getNrElements() > 0);
+  BOOST_CHECK(dfg.getNrLocalElements() <= dfg.getNrElements());
+  BOOST_CHECK(dfg.getLocalExtents().size() == dim);
 
   // set function values
   for (IndexType li = 0; li < dfg.getNrLocalElements(); ++li) {

--- a/tests/test_ftolerance.cpp
+++ b/tests/test_ftolerance.cpp
@@ -73,7 +73,7 @@ class TaskAdvFDM : public combigrid::Task {
 
     dfg_ =
         new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(), p);
-    phi_.resize(dfg_->getNrElements());
+    phi_.reshape(dfg_->getLocalExtents(), 0.);
 
     for (IndexType li = 0; li < dfg_->getNrElements(); ++li) {
       std::vector<double> coords(getDim());
@@ -102,7 +102,7 @@ class TaskAdvFDM : public combigrid::Task {
     double h1 = 1.0 / (double)l1;
 
     for (size_t i = 0; i < nsteps_; ++i) {
-      phi_.swap(dfg_->getElementVector());
+      std::swap(phi_, dfg_->getElementVector());
 
       for (IndexType li = 0; li < dfg_->getNrElements(); ++li) {
 
@@ -161,7 +161,7 @@ class TaskAdvFDM : public combigrid::Task {
   size_t stepsTotal_;
   size_t combiStep_;
   DistributedFullGrid<CombiDataType>* dfg_;
-  std::vector<CombiDataType> phi_;
+  typename DistributedFullGrid<CombiDataType>::TensorType phi_;
 
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version) {

--- a/tests/test_reduce.cpp
+++ b/tests/test_reduce.cpp
@@ -60,7 +60,7 @@ class TaskConst : public combigrid::Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(),
                                                   p, false, decomposition);
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = 10;
     }
@@ -70,7 +70,7 @@ class TaskConst : public combigrid::Task {
 
     std::cout << "run " << getCommRank(lcomm) << std::endl;
     
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       // BOOST_CHECK(abs(dfg_->getData()[li]));
       element = static_cast<double>(getLevelVector()[0]) / getLevelVector()[1];

--- a/tests/test_rescheduling.cpp
+++ b/tests/test_rescheduling.cpp
@@ -86,7 +86,7 @@ class TestingTask : public combigrid::Task {
     dfg_ = new DistributedFullGrid<CombiDataType>(getDim(), getLevelVector(), lcomm, getBoundary(),
                                                   p, false, decomposition);
 
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = 0; // default state is 0
     }
@@ -98,7 +98,7 @@ class TestingTask : public combigrid::Task {
 
     // std::cout << "run " << getCommRank(lcomm) << std::endl;
     
-    std::vector<CombiDataType>& elements = dfg_->getElementVector();
+    auto& elements = dfg_->getElementVector();
     for (auto& element : elements) {
       element = 10; // after run was executed the state is 10
     }
@@ -251,7 +251,7 @@ void checkRescheduling(size_t ngroup = 1, size_t nprocs = 1) {
       BOOST_REQUIRE(tasksContainSameValue(pgroup.getTasks()));
 
       for (auto& t : pgroup.getTasks()) {
-        std::vector<CombiDataType>& elements = t->getDistributedFullGrid().getElementVector();
+        auto& elements = t->getDistributedFullGrid().getElementVector();
         for (auto e : elements) {
           // Elements need to be always equal to 10 because
           // * first run: run is executed


### PR DESCRIPTION
This was a test that I got as far as to compile, but the numerics don't seem to work yet; needs some debugging.

Otherwise, this would allow to throw out most of the index calculation code bloat in DistributedFullGrid, which would be cool. Especially cool would be the sub-grid iteration stuff that is not yet merged into boost, found here:

https://github.com/boostorg/ublas/pull/126