### PR TITLE
Merge consecutive MPI_Allreduce operations into one

### DIFF
--- a/src/mpi/MPIMemory.cpp
+++ b/src/mpi/MPIMemory.cpp
@@ -51,16 +51,17 @@ int get_memory_usage_kb(unsigned long* vmrss_kb, unsigned long* vmsize_kb) {
 
 int get_all_memory_usage_kb(unsigned long* vmrss, unsigned long* vmsize, CommunicatorType comm) {
   MPI_Barrier(comm);
-  unsigned long vmrss_kb, vmsize_kb;
-  int ret_code = get_memory_usage_kb(&vmrss_kb, &vmsize_kb);
+  unsigned long vmbuf[2]; /* vmrss_kb, vmsize_kb */
+  int ret_code = get_memory_usage_kb(&vmbuf[0], &vmbuf[1]);
   if (ret_code != 0) {
     printf("Could not gather memory usage!\n");
     return ret_code;
   }
 
-  MPI_Allreduce(&vmrss_kb, vmrss, 1, MPI_UNSIGNED_LONG, MPI_SUM, comm);
+  MPI_Allreduce(MPI_IN_PLACE, vmbuf, 2, MPI_UNSIGNED_LONG, MPI_SUM, comm);
 
-  MPI_Allreduce(&vmsize_kb, vmsize, 1, MPI_UNSIGNED_LONG, MPI_SUM, comm);
+  *vmrss = vmbuf[0];
+  *vmsize = vmbuf[1];
   return 0;
 }
 


### PR DESCRIPTION
MPI_Allreduce is an expensive operation. Therefore, merge consecutive MPI_Allreduce operations by combining single elements into a multi element buffer and extract the results afterwards.