### PR TITLE
Fix compiler warning about deprecated std::bind1st

### DIFF
--- a/src/fullgrid/DistributedFullGrid.hpp
+++ b/src/fullgrid/DistributedFullGrid.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <iostream>
 #include <numeric>
 #include <string>
@@ -612,7 +613,7 @@ class SubarrayIterator : public SliceIterator<FG_ELEMENT> {
     std::vector<double> oneOverHByDivision;
     oneOverHByDivision.resize(gridSpacing_.size());
     std::transform(gridSpacing_.begin(), gridSpacing_.end(), oneOverHByDivision.begin(),
-                   std::bind1st(std::divides<double>(), 1));
+                   std::bind(std::divides<double>(), 1, std::placeholders::_1));
     for (DimType j = 0; j < dim_; j++) {
       assert(std::abs(oneOverHByDivision[j] < oneOverH[j]) < 1e-10);
       assert(oneOverHByDivision[j] == oneOverH[j]);


### PR DESCRIPTION
Replace deprecated std::bind1st with std::bind.