### PR TITLE
Feature true global reduce

### DIFF
--- a/examples/distributed_third_level/combi_example_worker_only.cpp
+++ b/examples/distributed_third_level/combi_example_worker_only.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv) {
         "dsg_" + std::to_string(systemNumber) + "_step" + std::to_string(i);
     std::string writeSparseGridFileToken = writeSparseGridFile + "_token.txt";
 
-    worker.combineLocalAndGlobal();
+    worker.combineLocalAndGlobal(theMPISystem()->getOutputRankInGlobalReduceComm());
     OUTPUT_GROUP_EXCLUSIVE_SECTION {
       worker.combineThirdLevelFileBasedWrite(writeSparseGridFile, writeSparseGridFileToken);
     }

--- a/examples/distributed_third_level/combi_example_worker_only.cpp
+++ b/examples/distributed_third_level/combi_example_worker_only.cpp
@@ -288,6 +288,25 @@ int main(int argc, char** argv) {
       std::cout << "combination " << i << " took: " << durationCombine << " seconds" << std::endl;
     }
   }
+  // run tasks for last time interval
+  worker.runAllTasks();
+  auto durationRun = Stats::getDuration("run") / 1000.0;
+  MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "last calculation " << ncombi
+                                             << " took: " << durationRun << " seconds" << std::endl;
+
+  if (evalMCError) {
+    Stats::startEvent("write interpolated");
+    worker.writeInterpolatedValuesSingleFile(interpolationCoords,
+                                             "worker_interpolated_" + std::to_string(systemNumber));
+    Stats::stopEvent("write interpolated");
+    OTHER_OUTPUT_GROUP_EXCLUSIVE_SECTION {
+      MASTER_EXCLUSIVE_SECTION {
+        std::cout << "last interpolation " << ncombi
+                  << " took: " << Stats::getDuration("write interpolated") / 1000.0 << " seconds"
+                  << std::endl;
+      }
+    }
+  }
   worker.exit();
 
   Stats::finalize();

--- a/src/manager/ProcessGroupWorker.cpp
+++ b/src/manager/ProcessGroupWorker.cpp
@@ -837,19 +837,20 @@ void ProcessGroupWorker::addFullGridsToUniformSG() {
   }
 }
 
-void ProcessGroupWorker::reduceUniformSG() {
+void ProcessGroupWorker::reduceUniformSG(RankType globalReduceRankThatCollects) {
   // we assume here that every task has the same number of grids, e.g. species in GENE
   auto numGrids = combiParameters_.getNumGrids();
 
   for (IndexType g = 0; g < numGrids; g++) {
-    CombiCom::distributedGlobalReduce(*combinedUniDSGVector_[g]);
+    CombiCom::distributedGlobalReduce(*combinedUniDSGVector_[g], globalReduceRankThatCollects);
     assert(CombiCom::sumAndCheckSubspaceSizes(*combinedUniDSGVector_[g]));
   }
 }
 
-void ProcessGroupWorker::combineLocalAndGlobal() {
-  assert(combinedUniDSGVector_.size() > 0 && "Initialize dsgu first with "
-                                             "initCombinedUniDSGVector()");
+void ProcessGroupWorker::combineLocalAndGlobal(RankType globalReduceRankThatCollects) {
+  assert(combinedUniDSGVector_.size() > 0 &&
+         "Initialize dsgu first with "
+         "initCombinedUniDSGVector()");
   // assert(combinedUniDSGVector_[0]->isSubspaceDataCreated());
 
   zeroDsgsData();
@@ -863,7 +864,7 @@ void ProcessGroupWorker::combineLocalAndGlobal() {
   Stats::stopEvent("local reduce");
 
   Stats::startEvent("global reduce");
-  reduceUniformSG();
+  reduceUniformSG(globalReduceRankThatCollects);
   Stats::stopEvent("global reduce");
 }
 

--- a/src/manager/ProcessGroupWorker.hpp
+++ b/src/manager/ProcessGroupWorker.hpp
@@ -58,12 +58,12 @@ class ProcessGroupWorker {
   void integrateCombinedSolution();
 
   /** reduction */
-  void reduceUniformSG();
+  void reduceUniformSG(RankType globalReduceRankThatCollects = MPI_PROC_NULL);
 
   /** combine on sparse grid with uniform decomposition of domain */
   void combineUniform();
 
-  void combineLocalAndGlobal();
+  void combineLocalAndGlobal(RankType globalReduceRankThatCollects = MPI_PROC_NULL);
 
   void deleteTasks();
 

--- a/tests/test_worker_only.cpp
+++ b/tests/test_worker_only.cpp
@@ -138,10 +138,7 @@ void checkWorkerOnly(size_t ngroup = 1, size_t nprocs = 1, BoundaryType boundary
 
   BOOST_CHECK_EQUAL(worker.getCurrentNumberOfCombinations(), 0);
   BOOST_TEST_CHECKPOINT("run first");
-  auto start = std::chrono::high_resolution_clock::now();
   worker.runAllTasks();
-  auto end = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   MASTER_EXCLUSIVE_SECTION {
     BOOST_TEST_MESSAGE("worker run first solver step: " << Stats::getDuration("run")
                                                         << " milliseconds");
@@ -149,10 +146,10 @@ void checkWorkerOnly(size_t ngroup = 1, size_t nprocs = 1, BoundaryType boundary
 
   for (size_t it = 0; it < ncombi - 1; ++it) {
     BOOST_TEST_CHECKPOINT("combine");
-    start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::high_resolution_clock::now();
     worker.combineUniform();
-    end = std::chrono::high_resolution_clock::now();
-    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     MASTER_EXCLUSIVE_SECTION {
       BOOST_TEST_MESSAGE("worker combine: " << duration.count() << " milliseconds");
     }
@@ -178,7 +175,7 @@ void checkWorkerOnly(size_t ngroup = 1, size_t nprocs = 1, BoundaryType boundary
   if (pretendThirdLevel) {
     std::string writeSparseGridFile = "worker_combine_step_dsg";
     std::string writeSparseGridFileToken = writeSparseGridFile + "_token.txt";
-    worker.combineLocalAndGlobal();
+    worker.combineLocalAndGlobal(theMPISystem()->getOutputRankInGlobalReduceComm());
     OUTPUT_GROUP_EXCLUSIVE_SECTION {
       BOOST_TEST_CHECKPOINT("worker write dsg");
       worker.combineThirdLevelFileBasedWrite(writeSparseGridFile, writeSparseGridFileToken);


### PR DESCRIPTION
third level distributed advection with only workers:
- Use MPI_Reduce instead of MPI_Allreduce in "global reduce" operation in combination
- adds another run+interpolate at end of time loop