### PR TITLE
Fix UFTP transfer with multiple uftp processes

### DIFF
--- a/third_level_manager/copy_file_from_hawk_to_ng.sh
+++ b/third_level_manager/copy_file_from_hawk_to_ng.sh
@@ -43,7 +43,7 @@ do
         starttime=`date +%s`
         for ((i=1; i<=PROCS; i++)); do
           echo "Block: $startblock-$endblock of $size"
-          uftp cp -t $THREADS_PER_PROC -n $STREAMS -i ~/.uftp/id_uftp_to_hlrs -u $USERHAWK $HAWKURL:$FILEHAWK_INSTANCE $PATHLRZ/ &
+          uftp cp -t $THREADS_PER_PROC -n $STREAMS -B "${startblock}-${endblock}-p" -i ~/.uftp/id_uftp_to_hlrs -u $USERHAWK $HAWKURL:$FILEHAWK_INSTANCE $PATHLRZ/ &
           startblock=$((endblock+1))
           if [ $i -eq $((PROCS)) ]; then
               endblock=$((size-1))

--- a/third_level_manager/copy_file_from_ng_to_hawk.sh
+++ b/third_level_manager/copy_file_from_ng_to_hawk.sh
@@ -36,7 +36,7 @@ do
         starttime=`date +%s`
         for ((i=1; i<=PROCS; i++)); do
           echo "Block: $startblock-$endblock of $size"
-          uftp cp -t $THREADS_PER_PROC -n $STREAMS  -i ~/.uftp/id_uftp_to_hlrs -u $USERHAWK $FILELRZ_INSTANCE $HAWKURL:$PATHHAWK/ &
+          uftp cp -t $THREADS_PER_PROC -n $STREAMS -B "${startblock}-${endblock}-p" -i ~/.uftp/id_uftp_to_hlrs -u $USERHAWK $FILELRZ_INSTANCE $HAWKURL:$PATHHAWK/ &
           startblock=$((endblock+1))
           if [ $i -eq $((PROCS)) ]; then
               endblock=$((size-1))


### PR DESCRIPTION
To start off with: This fix is based on the UFTP documentation and was not tested by myself. Please test before merging.

The transfer with multiple uftp processes should not copy the same data multiple times. Therefore use uftp's byte range option (-B) to specify the parts each process should transfer. Use the "-p" flag to only write the specific range.

See the uftp-client documentation for more details: https://uftp-docs.readthedocs.io/en/latest/user-docs/uftp-client/manual.html#byte-ranges