### PR TITLE
Fix MPI file access modes that should be combined with bit vector OR

### DIFF
--- a/src/fullgrid/DistributedFullGrid.hpp
+++ b/src/fullgrid/DistributedFullGrid.hpp
@@ -1181,7 +1181,7 @@ std::vector<FG_ELEMENT> getInterpolatedValues(
 
     // open file
     MPI_File fh;
-    MPI_File_open(getCommunicator(), filename, MPI_MODE_WRONLY + MPI_MODE_CREATE, MPI_INFO_NULL,
+    MPI_File_open(getCommunicator(), filename, MPI_MODE_WRONLY | MPI_MODE_CREATE, MPI_INFO_NULL,
                   &fh);
 
     MPI_Offset offset = 0;


### PR DESCRIPTION
The MPI 4.0 standard (p.646) specifies that access modes are 'a bit vector OR'. So do not rely on sum to work.