### PR TITLE
Fix allreduce error

### DIFF
--- a/src/combicom/CombiCom.hpp
+++ b/src/combicom/CombiCom.hpp
@@ -292,6 +292,7 @@ void distributedGlobalSubspaceReduce(SparseGridType& dsg, uint32_t maxMiBToSendP
     if constexpr (communicateAllAllocated) {
       datatypesByStartIndex =
           getReductionDatatypes(dsg, dsg.getCurrentlyAllocatedSubspaces(), maxMiBToSendPerThread);
+      assert(datatypesByStartIndex.size() == 1);
     } else {
       datatypesByStartIndex =
           getReductionDatatypes(dsg, commAndItsSubspaces.second, maxMiBToSendPerThread);

--- a/src/manager/ProcessGroupWorker.cpp
+++ b/src/manager/ProcessGroupWorker.cpp
@@ -909,9 +909,10 @@ void ProcessGroupWorker::waitForThirdLevelSizeUpdate() {
 
 int ProcessGroupWorker::reduceExtraSubspaceSizes(const std::string& filenameToRead,
                                                  bool overwrite) {
-  return this->getSparseGridWorker().reduceExtraSubspaceSizes(
+  auto numReducedSizes = this->getSparseGridWorker().reduceExtraSubspaceSizes(
       filenameToRead, this->combiParameters_.getCombinationVariant(), overwrite);
   this->getSparseGridWorker().zeroDsgsData(this->combiParameters_.getCombinationVariant());
+  return numReducedSizes;
 }
 
 int ProcessGroupWorker::reduceExtraSubspaceSizesFileBased(

--- a/src/manager/SparseGridWorker.hpp
+++ b/src/manager/SparseGridWorker.hpp
@@ -319,7 +319,8 @@ inline void SparseGridWorker::distributeChunkedBroadcasts(uint32_t maxMiBToSendP
       CombiCom::asyncBcastOutgroupDsgData<decltype(*dsg), true>(*dsg, broadcastSender,
                                                                 globalReduceComm, &request);
 
-      OUTPUT_GROUP_EXCLUSIVE_SECTION{} {
+      OUTPUT_GROUP_EXCLUSIVE_SECTION {}
+      else {
         // non-output ranks need to wait before they can extract
         if (roundNumber == 0) Stats::startEvent("wait 1st bcast");
         auto returnedValue = MPI_Wait(&request, MPI_STATUS_IGNORE);

--- a/src/manager/SparseGridWorker.hpp
+++ b/src/manager/SparseGridWorker.hpp
@@ -661,6 +661,7 @@ inline int SparseGridWorker::reduceExtraSubspaceSizes(const std::string& filenam
     // may need to re-size original spaces if original sparse grid was too small
     this->getCombinedUniDSGVector()[0]->maxReduceSubspaceSizes(*dsgToUse);
   }
+  this->reduceSubspaceSizesBetweenGroups(combinationVariant);
   return numSubspacesReduced;
 }
 

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -828,7 +828,7 @@ void testPretendThirdLevel(TestParams& testParams) {
   BOOST_CHECK(!TestHelper::testStrayMessages(testParams.comm));
 }
 
-BOOST_FIXTURE_TEST_SUITE(thirdLevel, TestHelper::BarrierAtEnd, *boost::unit_test::timeout(1700))
+BOOST_FIXTURE_TEST_SUITE(thirdLevel, TestHelper::BarrierAtEnd, *boost::unit_test::timeout(2000))
 
 BOOST_AUTO_TEST_CASE(test_0, *boost::unit_test::tolerance(TestHelper::tolerance) *
                                  boost::unit_test::disabled()) {
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(test_workers_2d, *boost::unit_test::tolerance(TestHelper::t
 
 // same as test_8 but only with workers
 BOOST_AUTO_TEST_CASE(test_8_workers, *boost::unit_test::tolerance(TestHelper::tolerance) *
-                                         boost::unit_test::timeout(750)) {
+                                         boost::unit_test::timeout(950)) {
   unsigned int numSystems = 2;
   unsigned int nprocs = 1;
   unsigned int ncombi = 3;

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -828,7 +828,7 @@ void testPretendThirdLevel(TestParams& testParams) {
   BOOST_CHECK(!TestHelper::testStrayMessages(testParams.comm));
 }
 
-BOOST_FIXTURE_TEST_SUITE(thirdLevel, TestHelper::BarrierAtEnd, *boost::unit_test::timeout(1500))
+BOOST_FIXTURE_TEST_SUITE(thirdLevel, TestHelper::BarrierAtEnd, *boost::unit_test::timeout(1700))
 
 BOOST_AUTO_TEST_CASE(test_0, *boost::unit_test::tolerance(TestHelper::tolerance) *
                                  boost::unit_test::disabled()) {
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(test_workers_2d, *boost::unit_test::tolerance(TestHelper::t
 
 // same as test_8 but only with workers
 BOOST_AUTO_TEST_CASE(test_8_workers, *boost::unit_test::tolerance(TestHelper::tolerance) *
-                                         boost::unit_test::timeout(550)) {
+                                         boost::unit_test::timeout(750)) {
   unsigned int numSystems = 2;
   unsigned int nprocs = 1;
   unsigned int ncombi = 3;


### PR DESCRIPTION
For some setups, we would get MPI_Allreduce truncation errors (but weirdly, not for the weak scaling setup).
Here is a fix along with a few more sanity checks.

PS: errors like
```
Abort(203042319) on node 4092 (rank 4092 in comm 0): Fatal error in PMPI_Wait: Other MPI error, error stack:
PMPI_Wait(205)..................: MPI_Wait(request=0x7ffd5b0155cc, status=0x1) failed
MPIR_Wait(105)..................: 
MPIDU_Sched_progress_state(1036): Invalid communicator
```
can be attributed to a "wrong" default of I_MPI_ADJUST_IBCAST that does not allow for non-power-of-two numbers of groups. parameters that worked for us (on IntelMPI 2019.12) were 1 and 4