### PR TITLE
three systems for file-based widely-distributed combination

### DIFF
--- a/examples/distributed_third_level/combi_example_worker_only.cpp
+++ b/examples/distributed_third_level/combi_example_worker_only.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
     if (hasThirdLevel) {
       systemNumber = cfg.get<unsigned int>("thirdLevel.systemNumber");
       numSystems = cfg.get<unsigned int>("thirdLevel.numSystems");
-      assert(numSystems == 2);
+      assert(numSystems > 1);
       assert(systemNumber < numSystems);
       extraSparseGrid = cfg.get<bool>("thirdLevel.extraSparseGrid", true);
       MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "running in file-based third level mode"
@@ -269,18 +269,24 @@ int main(int argc, char** argv) {
                   << " took: " << durationCombineWrite << " seconds" << std::endl;
       }
       auto startCombineRead = std::chrono::high_resolution_clock::now();
-      std::string readSparseGridFile;
+      std::vector<std::string> readSparseGridFiles;
+      std::vector<std::string> readSparseGridFileTokens;
       if (hasThirdLevel) {
-        readSparseGridFile =
-            "dsg_" + std::to_string((systemNumber + 1) % 2) + "_step" + std::to_string(i);
-        std::string readSparseGridFileToken = readSparseGridFile + "_token.txt";
-        worker.combineReadDistributeSystemWide({readSparseGridFile}, {readSparseGridFileToken}, false,
+        for (unsigned int otherSystemNumber = 0; otherSystemNumber < numSystems;
+             ++otherSystemNumber) {
+          if (otherSystemNumber != systemNumber) {
+            readSparseGridFiles.emplace_back("dsg_" + std::to_string(otherSystemNumber) + "_step" +
+                                             std::to_string(i));
+            readSparseGridFileTokens.emplace_back(readSparseGridFiles.back() + "_token.txt");
+          }
+        }
+        worker.combineReadDistributeSystemWide(readSparseGridFiles, readSparseGridFileTokens, false,
                                                false);
 
       } else {
-        readSparseGridFile = writeSparseGridFile;
-        worker.combineReadDistributeSystemWide({readSparseGridFile}, {writeSparseGridFileToken}, true,
-                                               false);
+        readSparseGridFiles.emplace_back(writeSparseGridFile);
+        worker.combineReadDistributeSystemWide(readSparseGridFiles, {writeSparseGridFileToken},
+                                               true, false);
       }
       MIDDLE_PROCESS_EXCLUSIVE_SECTION {
         auto endCombineRead = std::chrono::high_resolution_clock::now();
@@ -288,7 +294,7 @@ int main(int argc, char** argv) {
             std::chrono::duration_cast<std::chrono::seconds>(endCombineRead - startCombineRead)
                 .count();
         std::cout << getTimeStamp() << "combination-wait/read/reduce " << i
-                  << " took: " << durationCombineRead << " seconds ; read " << readSparseGridFile
+                  << " took: " << durationCombineRead << " seconds ; read " << readSparseGridFiles
                   << std::endl;
       }
       Stats::stopEvent("combine");

--- a/examples/distributed_third_level/combi_example_worker_only.cpp
+++ b/examples/distributed_third_level/combi_example_worker_only.cpp
@@ -274,12 +274,12 @@ int main(int argc, char** argv) {
         readSparseGridFile =
             "dsg_" + std::to_string((systemNumber + 1) % 2) + "_step" + std::to_string(i);
         std::string readSparseGridFileToken = readSparseGridFile + "_token.txt";
-        worker.combineReadDistributeSystemWide(readSparseGridFile, readSparseGridFileToken, false,
+        worker.combineReadDistributeSystemWide({readSparseGridFile}, {readSparseGridFileToken}, false,
                                                false);
 
       } else {
         readSparseGridFile = writeSparseGridFile;
-        worker.combineReadDistributeSystemWide(readSparseGridFile, writeSparseGridFileToken, true,
+        worker.combineReadDistributeSystemWide({readSparseGridFile}, {writeSparseGridFileToken}, true,
                                                false);
       }
       MIDDLE_PROCESS_EXCLUSIVE_SECTION {

--- a/examples/distributed_third_level/combi_example_worker_only.cpp
+++ b/examples/distributed_third_level/combi_example_worker_only.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
           ctschemeFile.substr(
               0, ctschemeFile.length() - std::string("_part0_00008groups.json").length()) +
           "conjoint.sizes";
-      worker.reduceExtraSubspaceSizes(conjointSubspaceFileName, true);
+      worker.reduceExtraSubspaceSizes({conjointSubspaceFileName}, true);
     }
 
     OUTPUT_GROUP_EXCLUSIVE_SECTION {

--- a/src/combischeme/CombiMinMaxScheme.hpp
+++ b/src/combischeme/CombiMinMaxScheme.hpp
@@ -141,7 +141,7 @@ inline void CombiMinMaxScheme::print(std::ostream& os) const {
 
 class CombiMinMaxSchemeFromFile : public CombiMinMaxScheme {
  public:
-  CombiMinMaxSchemeFromFile(DimType dim, LevelVector& lmin, LevelVector& lmax,
+  CombiMinMaxSchemeFromFile(DimType dim, const LevelVector& lmin, const LevelVector& lmax,
                             std::string ctschemeFile, const CommunicatorType& comm = MPI_COMM_WORLD)
       : CombiMinMaxScheme(dim, lmin, lmax) {
     // read in CT scheme, if applicable

--- a/src/combischeme/CombiThirdLevelScheme.cpp
+++ b/src/combischeme/CombiThirdLevelScheme.cpp
@@ -1,20 +1,13 @@
+#include "combischeme/CombiThirdLevelScheme.hpp"
+
 #include <numeric>
 #include <vector>
 
-#include "combischeme/CombiThirdLevelScheme.hpp"
-
-
 namespace combigrid {
-/**Computes the distribution of a classical scheme to the systems of the
- * third level combination.
- */
-void CombiThirdLevelScheme::createThirdLevelScheme(const std::vector<LevelVector>& levels,
-                                                   const std::vector<real>& coeffs,
-                                                   unsigned int systemNumber,
-                                                   unsigned int numSystems,
-                                                   std::vector<LevelVector>& newLevels,
-                                                   std::vector<real>& newCoeffs,
-                                                   std::vector<real> fractionsOfScheme) {
+void CombiThirdLevelScheme::createThirdLevelScheme(
+    const std::vector<LevelVector>& levels, const std::vector<real>& coeffs,
+    unsigned int systemNumber, unsigned int numSystems, std::vector<LevelVector>& newLevels,
+    std::vector<real>& newCoeffs, const std::vector<real>& fractionsOfScheme) {
   assert(!levels.empty() && !coeffs.empty());
   assert(levels.size() == coeffs.size());
 
@@ -24,53 +17,51 @@ void CombiThirdLevelScheme::createThirdLevelScheme(const std::vector<LevelVector
     return;
   }
 
-  assert(numSystems <= 2 && "Implemented for maximal 2 systems");
-
   // decompose scheme
   std::vector<std::vector<LevelVector>> decomposedScheme;
   std::vector<std::vector<combigrid::real>> decomposedCoeffs;
-  decomposeScheme(levels, coeffs, decomposedScheme, decomposedCoeffs, numSystems, fractionsOfScheme);
+  decomposeScheme(levels, coeffs, decomposedScheme, decomposedCoeffs, numSystems,
+                  fractionsOfScheme);
 
   // assign part to system
-  newLevels  = decomposedScheme[systemNumber];
+  newLevels = decomposedScheme[systemNumber];
   newCoeffs = decomposedCoeffs[systemNumber];
-
 }
 
-
-/**Computes an optimal disjunct decomposition of the given combination scheme.
- * Each part can be assigned to a system in the third level reduce and
- * the amount of shared grid points is minimal.
- *
- * We assume only 2 systems participating.
- * For example purpose we just split the scheme in half and later assign each half
- * to a system.
- * TODO Implement for arbitrary number of systems
- */
 void CombiThirdLevelScheme::decomposeScheme(const std::vector<LevelVector>& fullScheme,
                                             const std::vector<real> fullSchemeCoeffs,
                                             std::vector<std::vector<LevelVector>>& decomposedScheme,
                                             std::vector<std::vector<real>>& decomposedCoeffs,
-                                            size_t numSystems, std::vector<real> fractionsOfScheme) {
-  auto fracSum = std::accumulate(fractionsOfScheme.begin(), fractionsOfScheme.end(), 0., std::plus<real>());
+                                            size_t numSystems,
+                                            const std::vector<real>& fractionsOfScheme) {
+  auto fracSum =
+      std::accumulate(fractionsOfScheme.begin(), fractionsOfScheme.end(), 0., std::plus<real>());
   assert(std::abs(fracSum - 1.) < 1e-3);
-  auto numGridsFirstSystem = std::round(static_cast<real>(fullScheme.size()) * fractionsOfScheme[0]);
-  auto mid = fullScheme.begin() + numGridsFirstSystem;
-  auto midC = fullSchemeCoeffs.begin() + numGridsFirstSystem;
-  std::vector<LevelVector> lowerHalf(fullScheme.begin(), mid);
-  std::vector<real> lowerCoeffs(fullSchemeCoeffs.begin(), midC);
-  std::vector<LevelVector> upperHalf(mid, fullScheme.end());
-  std::vector<real> upperCoeffs(midC, fullSchemeCoeffs.end());
-
-  assert( !lowerHalf.empty() && !upperHalf.empty() );
-  assert(lowerHalf.size() + upperHalf.size() == fullScheme.size());
-  assert(lowerCoeffs.size() + upperCoeffs.size() == fullSchemeCoeffs.size());
-
+  assert(fractionsOfScheme.size() == numSystems);
   decomposedScheme.reserve(numSystems);
   decomposedCoeffs.reserve(numSystems);
-  decomposedScheme.push_back(std::move(lowerHalf));
-  decomposedScheme.push_back(std::move(upperHalf));
-  decomposedCoeffs.push_back(std::move(lowerCoeffs));
-  decomposedCoeffs.push_back(std::move(upperCoeffs));
+
+  real scannedFrac = 0.;
+  auto beginNextL = fullScheme.begin();
+  auto beginNextC = fullSchemeCoeffs.begin();
+  for (auto frac : fractionsOfScheme) {
+    scannedFrac += frac;
+    auto currentSystemUpToIndex = std::round(static_cast<real>(fullScheme.size()) * scannedFrac);
+    auto endIntervalL = fullScheme.begin() + currentSystemUpToIndex;
+    auto endIntervalC = fullSchemeCoeffs.begin() + currentSystemUpToIndex;
+    decomposedScheme.emplace_back(beginNextL, endIntervalL);
+    decomposedCoeffs.emplace_back(beginNextC, endIntervalC);
+    beginNextL = endIntervalL;
+    beginNextC = endIntervalC;
+  }
+  
+  // assert that all are assigned
+  assert(std::accumulate(decomposedScheme.begin(), decomposedScheme.end(), 0,
+                         [](size_t a, const std::vector<LevelVector>& l) {
+                           return a + l.size();
+                         }) == fullScheme.size());
+  assert(std::accumulate(decomposedCoeffs.begin(), decomposedCoeffs.end(), 0,
+                         [](size_t a, const std::vector<real>& c) { return a + c.size(); }) ==
+         fullSchemeCoeffs.size());
 }
-}
+}  // namespace combigrid

--- a/src/combischeme/CombiThirdLevelScheme.cpp
+++ b/src/combischeme/CombiThirdLevelScheme.cpp
@@ -29,7 +29,7 @@ void CombiThirdLevelScheme::createThirdLevelScheme(
 }
 
 void CombiThirdLevelScheme::decomposeScheme(const std::vector<LevelVector>& fullScheme,
-                                            const std::vector<real> fullSchemeCoeffs,
+                                            const std::vector<real>& fullSchemeCoeffs,
                                             std::vector<std::vector<LevelVector>>& decomposedScheme,
                                             std::vector<std::vector<real>>& decomposedCoeffs,
                                             size_t numSystems,
@@ -54,7 +54,7 @@ void CombiThirdLevelScheme::decomposeScheme(const std::vector<LevelVector>& full
     beginNextL = endIntervalL;
     beginNextC = endIntervalC;
   }
-  
+
   // assert that all are assigned
   assert(std::accumulate(decomposedScheme.begin(), decomposedScheme.end(), 0,
                          [](size_t a, const std::vector<LevelVector>& l) {

--- a/src/combischeme/CombiThirdLevelScheme.hpp
+++ b/src/combischeme/CombiThirdLevelScheme.hpp
@@ -18,7 +18,7 @@ class CombiThirdLevelScheme {
    * Each part can be assigned to a system in the third level reduce.
    */
   static void decomposeScheme(const std::vector<LevelVector>& fullScheme,
-                              const std::vector<real> fullSchemeCoeffs,
+                              const std::vector<real>& fullSchemeCoeffs,
                               std::vector<std::vector<LevelVector>>& decomposedScheme,
                               std::vector<std::vector<real>>& decomposedCoeffs,
                               size_t numSystems = 2,

--- a/src/combischeme/CombiThirdLevelScheme.hpp
+++ b/src/combischeme/CombiThirdLevelScheme.hpp
@@ -3,31 +3,26 @@
 namespace combigrid {
 
 class CombiThirdLevelScheme {
+ public:
+  /** Computes the distribution of a classical scheme to the systems of the
+   * third level combination.
+   */
+  static void createThirdLevelScheme(const std::vector<LevelVector>& levels,
+                                     const std::vector<real>& coeffs, unsigned int systemNumber,
+                                     unsigned int numSystems, std::vector<LevelVector>& newLevels,
+                                     std::vector<real>& newCoeffs,
+                                     const std::vector<real>& fractionsOfScheme = {0.5, 0.5});
 
-  public:
-    /**Creates system specific scheme for third level combination based on the
-     * given full scheme (levels, coeffs). Additionally returns the list of
-     * subspaces which all participating systems have in common.
-     *
-     * I packed that into a separate class because scheme generation should be
-     * supported for other schemes than minmax e.g. schemes read directly from
-     * file.
-     */
-    static void createThirdLevelScheme(const std::vector<LevelVector>& levels,
-                                       const std::vector<real>& coeffs,
-                                       unsigned int systemNumber,
-                                       unsigned int numSystems,
-                                       std::vector<LevelVector>& newLevels,
-                                       std::vector<real>& newCoeffs,
-                                       std::vector<real> fractionsOfScheme = {0.5,0.5});
-
-  private:
-    static void decomposeScheme(const std::vector<LevelVector>& fullScheme,
-                                const std::vector<real> fullSchemeCoeffs,
-                                std::vector<std::vector<LevelVector>>& decomposedScheme,
-                                std::vector<std::vector<real>>& decomposedCoeffs,
-                                size_t numSystems = 2,
-                                std::vector<real> fractionsOfScheme = {0.5,0.5});
+ private:
+  /** Computes a (non-optimal) disjunct decomposition of the given combination scheme.
+   * Each part can be assigned to a system in the third level reduce.
+   */
+  static void decomposeScheme(const std::vector<LevelVector>& fullScheme,
+                              const std::vector<real> fullSchemeCoeffs,
+                              std::vector<std::vector<LevelVector>>& decomposedScheme,
+                              std::vector<std::vector<real>>& decomposedCoeffs,
+                              size_t numSystems = 2,
+                              const std::vector<real>& fractionsOfScheme = {0.5, 0.5});
 };
 
-}
+}  // namespace combigrid

--- a/src/io/FileInputOutput.cpp
+++ b/src/io/FileInputOutput.cpp
@@ -1,5 +1,4 @@
 #include "io/FileInputOutput.hpp"
-
 #include <filesystem>
 #include <fstream>
 #include <numeric>
@@ -41,5 +40,15 @@ void writeConcatenatedFileRootOnly(const char* data, int sizeOfData, const std::
       out << recvBuffer;
       out.close();
     }
+}
+
+bool getFileExistsRootOnly(const std::string& fileName, CommunicatorType comm, RankType myRank,
+                           RankType rootRank) {
+  bool doesItExist = false;
+  if (myRank == rootRank) {
+    doesItExist = std::filesystem::exists(fileName);
+  }
+  MPI_Bcast(&doesItExist, 1, MPI_C_BOOL, rootRank, comm);
+  return doesItExist;
 }
 }  // namespace combigrid

--- a/src/io/FileInputOutput.hpp
+++ b/src/io/FileInputOutput.hpp
@@ -6,8 +6,13 @@
 
 #include <string>
 
+#include "utils/Types.hpp"
+
 namespace combigrid {
 void writeConcatenatedFileRootOnly(const char* data, int sizeOfData, const std::string& path,
                                    MPI_Comm comm, bool replaceExistingFile = false);
+
+bool getFileExistsRootOnly(const std::string& fileName, CommunicatorType comm, RankType myRank,
+                           RankType rootRank = 0);
 
 }  // namespace combigrid

--- a/src/manager/ProcessGroupManager.cpp
+++ b/src/manager/ProcessGroupManager.cpp
@@ -112,10 +112,10 @@ bool ProcessGroupManager::combineThirdLevel(const ThirdLevelUtils& thirdLevel,
   return true;
 }
 
-bool ProcessGroupManager::combineThirdLevelFileBased(std::string filenamePrefixToWrite,
-                                                     std::string writeCompleteTokenFileName,
-                                                     std::string filenamePrefixToRead,
-                                                     std::string startReadingTokenFileName) {
+bool ProcessGroupManager::combineThirdLevelFileBased(const std::string& filenamePrefixToWrite,
+                                                     const std::string& writeCompleteTokenFileName,
+                                                     const std::string& filenamePrefixToRead,
+                                                     const std::string& startReadingTokenFileName) {
   assert(waitStatus() == PROCESS_GROUP_WAIT);
   sendSignalAndReceive(COMBINE_THIRD_LEVEL_FILE);
 
@@ -129,8 +129,8 @@ bool ProcessGroupManager::combineThirdLevelFileBased(std::string filenamePrefixT
   return this->waitStatus() == PROCESS_GROUP_WAIT;
 }
 
-bool ProcessGroupManager::combineThirdLevelFileBasedWrite(std::string filenamePrefixToWrite,
-                                                          std::string writeCompleteTokenFileName) {
+bool ProcessGroupManager::combineThirdLevelFileBasedWrite(
+    const std::string& filenamePrefixToWrite, const std::string& writeCompleteTokenFileName) {
   assert(waitStatus() == PROCESS_GROUP_WAIT);
   sendSignalAndReceive(COMBINE_WRITE_DSGS);
 
@@ -144,7 +144,7 @@ bool ProcessGroupManager::combineThirdLevelFileBasedWrite(std::string filenamePr
 }
 
 bool ProcessGroupManager::combineThirdLevelFileBasedReadReduce(
-    std::string filenamePrefixToRead, std::string startReadingTokenFileName) {
+    const std::string& filenamePrefixToRead, const std::string& startReadingTokenFileName) {
   assert(waitStatus() == PROCESS_GROUP_WAIT);
   sendSignalAndReceive(COMBINE_READ_DSGS_AND_REDUCE);
 
@@ -557,7 +557,7 @@ void sendLevelVector(const LevelVector& leval, RankType pgroupRootID) {
            theMPISystem()->getGlobalComm());
 }
 
-bool ProcessGroupManager::parallelEval(const LevelVector& leval, std::string& filename) {
+bool ProcessGroupManager::parallelEval(const LevelVector& leval, const std::string& filename) {
   // can only send sync signal when in wait state, so check first
   assert(status_ == PROCESS_GROUP_WAIT);
 
@@ -762,14 +762,14 @@ bool ProcessGroupManager::writeCombigridsToVTKPlotFile() {
   return true;
 }
 
-bool ProcessGroupManager::writeDSGsToDisk(std::string filenamePrefix) {
+bool ProcessGroupManager::writeDSGsToDisk(const std::string& filenamePrefix) {
   assert(waitStatus() == PROCESS_GROUP_WAIT);
   sendSignalAndReceive(WRITE_DSGS_TO_DISK);
   MPIUtils::sendClass(&filenamePrefix, pgroupRootID_, theMPISystem()->getGlobalComm());
   return true;
 }
 
-bool ProcessGroupManager::readDSGsFromDisk(std::string filenamePrefix) {
+bool ProcessGroupManager::readDSGsFromDisk(const std::string& filenamePrefix) {
   assert(waitStatus() == PROCESS_GROUP_WAIT);
   sendSignalAndReceive(READ_DSGS_FROM_DISK);
   MPIUtils::sendClass(&filenamePrefix, pgroupRootID_, theMPISystem()->getGlobalComm());

--- a/src/manager/ProcessGroupManager.hpp
+++ b/src/manager/ProcessGroupManager.hpp
@@ -52,16 +52,16 @@ class ProcessGroupManager {
   bool combineThirdLevel(const ThirdLevelUtils& thirdLevel, CombiParameters& params,
                          bool isSendingFirst);
 
-  bool combineThirdLevelFileBased(std::string filenamePrefixToWrite,
-                                  std::string writeCompleteTokenFileName,
-                                  std::string filenamePrefixToRead,
-                                  std::string startReadingTokenFileName);
+  bool combineThirdLevelFileBased(const std::string& filenamePrefixToWrite,
+                                  const std::string& writeCompleteTokenFileName,
+                                  const std::string& filenamePrefixToRead,
+                                  const std::string& startReadingTokenFileName);
 
-  bool combineThirdLevelFileBasedWrite(std::string filenamePrefixToWrite,
-                                       std::string writeCompleteTokenFileName);
+  bool combineThirdLevelFileBasedWrite(const std::string& filenamePrefixToWrite,
+                                       const std::string& writeCompleteTokenFileName);
 
-  bool combineThirdLevelFileBasedReadReduce(std::string filenamePrefixToRead,
-                                            std::string startReadingTokenFileName);
+  bool combineThirdLevelFileBasedReadReduce(const std::string& filenamePrefixToRead,
+                                            const std::string& startReadingTokenFileName);
 
   bool pretendCombineThirdLevelForWorkers(CombiParameters& params);
 
@@ -82,7 +82,7 @@ class ProcessGroupManager {
 
   bool recoverCommunicators();
 
-  bool parallelEval(const LevelVector& leval, std::string& filename);
+  bool parallelEval(const LevelVector& leval, const std::string& filename);
 
   void writeSparseGridMinMaxCoefficients(const std::string& filename);
 
@@ -121,17 +121,15 @@ class ProcessGroupManager {
 
   bool hasTask(size_t taskID){
     auto foundIt = std::find_if(tasks_.begin(), tasks_.end(),
-                        [taskID](Task* t){
-                          return ((t->getID()) == taskID);
-                        });
+                                [taskID](Task* t) { return ((t->getID()) == taskID); });
     return foundIt != tasks_.end();
   }
 
   bool writeCombigridsToVTKPlotFile();
 
-  bool writeDSGsToDisk(std::string filenamePrefix);
+  bool writeDSGsToDisk(const std::string& filenamePrefix);
 
-  bool readDSGsFromDisk(std::string filenamePrefix);
+  bool readDSGsFromDisk(const std::string& filenamePrefix);
 
   void storeTaskReference(Task* t);
 

--- a/src/manager/ProcessGroupWorker.cpp
+++ b/src/manager/ProcessGroupWorker.cpp
@@ -209,16 +209,16 @@ SignalType ProcessGroupWorker::wait() {
     } break;
     case COMBINE_READ_DSGS_AND_REDUCE: {
       Stats::startEvent("combine third level read");
-      combineThirdLevelFileBasedReadReduce(receiveStringFromManagerAndBroadcastToGroup(),
-                                           receiveStringFromManagerAndBroadcastToGroup());
+      combineThirdLevelFileBasedReadReduce({receiveStringFromManagerAndBroadcastToGroup()},
+                                           {receiveStringFromManagerAndBroadcastToGroup()});
       Stats::stopEvent("combine third level read");
     } break;
     case COMBINE_THIRD_LEVEL_FILE: {
       Stats::startEvent("combine third level file");
       combineThirdLevelFileBased(receiveStringFromManagerAndBroadcastToGroup(),
                                  receiveStringFromManagerAndBroadcastToGroup(),
-                                 receiveStringFromManagerAndBroadcastToGroup(),
-                                 receiveStringFromManagerAndBroadcastToGroup());
+                                 {receiveStringFromManagerAndBroadcastToGroup()},
+                                 {receiveStringFromManagerAndBroadcastToGroup()});
       Stats::stopEvent("combine third level file");
     } break;
     case WAIT_FOR_TL_COMBI_RESULT: {
@@ -812,7 +812,7 @@ void ProcessGroupWorker::removeReadingFiles(const std::string& filenamePrefixToR
 }
 
 void ProcessGroupWorker::waitForTokenFile(const std::string& startReadingTokenFileName) const {
-  OUTPUT_GROUP_EXCLUSIVE_SECTION{
+  OUTPUT_GROUP_EXCLUSIVE_SECTION {
     Stats::startEvent("wait SG");
     MASTER_EXCLUSIVE_SECTION {
       std::cout << "Waiting for token file " << startReadingTokenFileName << std::endl;
@@ -829,19 +829,35 @@ void ProcessGroupWorker::waitForTokenFile(const std::string& startReadingTokenFi
 }
 
 int ProcessGroupWorker::readReduce(const std::string& filenamePrefixToRead, bool overwrite) {
-  return getSparseGridWorker().readReduce(filenamePrefixToRead,
-               this->combiParameters_.getChunkSizeInMebibybtePerThread(), overwrite);
+  return getSparseGridWorker().readReduce(
+      filenamePrefixToRead, this->combiParameters_.getChunkSizeInMebibybtePerThread(), overwrite);
 }
 
 void ProcessGroupWorker::combineThirdLevelFileBasedReadReduce(
-    const std::string& filenamePrefixToRead, const std::string& startReadingTokenFileName,
-    bool overwrite, bool keepSparseGridFiles) {
-  // wait until we can start to read
-  this->waitForTokenFile(startReadingTokenFileName);
-
-  overwrite ? Stats::startEvent("read SG") : Stats::startEvent("read/reduce SG");
-  int numRead = this->readReduce(filenamePrefixToRead, overwrite);
-  overwrite ? Stats::stopEvent("read SG") : Stats::stopEvent("read/reduce SG");
+    const std::vector<std::string>& filenamePrefixesToRead,
+    const std::vector<std::string>& startReadingTokenFileNames, bool overwrite,
+    bool keepSparseGridFiles) {
+  // wait until we can start to read any of the files
+  std::set<size_t> indicesStillToReadReduce;
+  for (size_t i = 0; i < filenamePrefixesToRead.size(); ++i) {
+    indicesStillToReadReduce.insert(i);
+  }
+  while (!indicesStillToReadReduce.empty()) {
+    for (auto it = indicesStillToReadReduce.begin(); it != indicesStillToReadReduce.end(); ++it) {
+      if (combigrid::getFileExistsRootOnly(startReadingTokenFileNames[*it],
+                                           theMPISystem()->getOutputGroupComm(),
+                                           theMPISystem()->getOutputGroupRank())) {
+        overwrite ? Stats::startEvent("read SG") : Stats::startEvent("read/reduce SG");
+        int numRead = this->readReduce(filenamePrefixesToRead[*it], overwrite);
+        assert(numRead > 0);
+        overwrite ? Stats::stopEvent("read SG") : Stats::stopEvent("read/reduce SG");
+        indicesStillToReadReduce.erase(it);
+        break;  // because iterators may be invalidated
+      }
+    }
+    // wait for 200ms
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
 
   MPI_Request request = MPI_REQUEST_NULL;
   if (this->combiParameters_.getCombinationVariant() ==
@@ -851,8 +867,6 @@ void ProcessGroupWorker::combineThirdLevelFileBasedReadReduce(
 
     this->dehierarchizeAllTasks();
   } else {
-    assert(numRead > 0);
-
     // I need to broadcast
     this->getSparseGridWorker().startSingleBroadcastDSGs(
         this->combiParameters_.getCombinationVariant(), theMPISystem()->getGlobalReduceRank(),
@@ -861,17 +875,22 @@ void ProcessGroupWorker::combineThirdLevelFileBasedReadReduce(
     // update fgs
     updateFullFromCombinedSparseGrids();
   }
-  this->removeReadingFiles(filenamePrefixToRead, startReadingTokenFileName, keepSparseGridFiles);
+  for (size_t i = 0; i < filenamePrefixesToRead.size(); ++i) {
+    // remove reading token and sparse grid file(s)
+    this->removeReadingFiles(filenamePrefixesToRead[i], startReadingTokenFileNames[i],
+                             keepSparseGridFiles);
+  }
 
   auto returnedValue = MPI_Wait(&request, MPI_STATUS_IGNORE);
   assert(returnedValue == MPI_SUCCESS);
 }
 
 void ProcessGroupWorker::combineReadDistributeSystemWide(
-    const std::string& filenamePrefixToRead, const std::string& startReadingTokenFileName,
-    bool overwrite, bool keepSparseGridFiles) {
+    const std::vector<std::string>& filenamePrefixesToRead,
+    const std::vector<std::string>& startReadingTokenFileNames, bool overwrite,
+    bool keepSparseGridFiles) {
   OUTPUT_GROUP_EXCLUSIVE_SECTION {
-    this->combineThirdLevelFileBasedReadReduce(filenamePrefixToRead, startReadingTokenFileName,
+    this->combineThirdLevelFileBasedReadReduce(filenamePrefixesToRead, startReadingTokenFileNames,
                                                overwrite, keepSparseGridFiles);
   }
   else {
@@ -887,12 +906,12 @@ void ProcessGroupWorker::combineReadDistributeSystemWide(
   }
 }
 
-void ProcessGroupWorker::combineThirdLevelFileBased(const std::string& filenamePrefixToWrite,
-                                                    const std::string& writeCompleteTokenFileName,
-                                                    const std::string& filenamePrefixToRead,
-                                                    const std::string& startReadingTokenFileName) {
+void ProcessGroupWorker::combineThirdLevelFileBased(
+    const std::string& filenamePrefixToWrite, const std::string& writeCompleteTokenFileName,
+    const std::vector<std::string>& filenamePrefixesToRead,
+    const std::vector<std::string>& startReadingTokenFileNames) {
   this->combineThirdLevelFileBasedWrite(filenamePrefixToWrite, writeCompleteTokenFileName);
-  this->combineThirdLevelFileBasedReadReduce(filenamePrefixToRead, startReadingTokenFileName);
+  this->combineThirdLevelFileBasedReadReduce(filenamePrefixesToRead, startReadingTokenFileNames);
 }
 
 void ProcessGroupWorker::setExtraSparseGrid(bool initializeSizes) {

--- a/src/manager/ProcessGroupWorker.hpp
+++ b/src/manager/ProcessGroupWorker.hpp
@@ -92,26 +92,28 @@ class ProcessGroupWorker {
 
   int combineThirdLevelFileBasedWrite(const std::string& filenamePrefixToWrite,
                                       const std::string& writeCompleteTokenFileName);
+
   void waitForTokenFile(const std::string& startReadingTokenFileName) const;
 
   void removeReadingFiles(const std::string& filenamePrefixToRead,
-              const std::string& startReadingTokenFileName, bool keepSparseGridFiles) const;
+                          const std::string& startReadingTokenFileName,
+                          bool keepSparseGridFiles) const;
 
   int readReduce(const std::string& filenamePrefixToRead, bool overwrite);
 
-  void combineThirdLevelFileBasedReadReduce(const std::string& filenamePrefixToRead,
-                                            const std::string& startReadingTokenFileName,
-                                            bool overwrite = false,
-                                            bool keepSparseGridFiles = false);
+  void combineThirdLevelFileBasedReadReduce(
+      const std::vector<std::string>& filenamePrefixesToRead,
+      const std::vector<std::string>& startReadingTokenFileNames, bool overwrite = false,
+      bool keepSparseGridFiles = false);
 
-  void combineReadDistributeSystemWide(const std::string& filenamePrefixToRead,
-                                       const std::string& startReadingTokenFileName,
+  void combineReadDistributeSystemWide(const std::vector<std::string>& filenamePrefixesToRead,
+                                       const std::vector<std::string>& startReadingTokenFileNames,
                                        bool overwrite = false, bool keepSparseGridFiles = false);
 
   void combineThirdLevelFileBased(const std::string& filenamePrefixToWrite,
                                   const std::string& writeCompleteTokenFileName,
-                                  const std::string& filenamePrefixToRead,
-                                  const std::string& startReadingTokenFileName);
+                                  const std::vector<std::string>& filenamePrefixToRead,
+                                  const std::vector<std::string>& startReadingTokenFileName);
 
   /** waits until the third level pg or output group bcasts the combined solution and updates
    * fgs */

--- a/src/manager/ProcessGroupWorker.hpp
+++ b/src/manager/ProcessGroupWorker.hpp
@@ -122,12 +122,13 @@ class ProcessGroupWorker {
   /** computes a max reduce on the dsg's subspace sizes with the other systems */
   void reduceSubspaceSizesThirdLevel(bool thirdLevelExtraSparseGrid);
 
-  int reduceExtraSubspaceSizes(const std::string& filenameToRead, bool overwrite = false);
+  int reduceExtraSubspaceSizes(const std::vector<std::string>& filenameToRead,
+                               bool overwrite = false);
 
   int reduceExtraSubspaceSizesFileBased(const std::string& filenamePrefixToWrite,
-                                   const std::string& writeCompleteTokenFileName,
-                                   const std::string& filenamePrefixToRead,
-                                   const std::string& startReadingTokenFileName);
+                                        const std::string& writeCompleteTokenFileName,
+                                        const std::vector<std::string>& filenamePrefixToRead,
+                                        const std::vector<std::string>& startReadingTokenFileName);
 
   /** receives reduced sizes from tl pgroup and updates the dsgs */
   void waitForThirdLevelSizeUpdate();

--- a/src/manager/ProcessManager.hpp
+++ b/src/manager/ProcessManager.hpp
@@ -77,19 +77,19 @@ class ProcessManager {
 
   inline void combineThirdLevel();
 
-  inline void combineThirdLevelFileBasedWrite(std::string filenamePrefixToWrite,
-                                              std::string writeCompleteTokenFileName);
+  inline void combineThirdLevelFileBasedWrite(const std::string& filenamePrefixToWrite,
+                                              const std::string& writeCompleteTokenFileName);
 
-  inline void combineThirdLevelFileBasedReadReduce(std::string filenamePrefixToRead,
-                                                   std::string startReadingTokenFileName);
+  inline void combineThirdLevelFileBasedReadReduce(const std::string& filenamePrefixToRead,
+                                                   const std::string& startReadingTokenFileName);
 
-  inline void combineThirdLevelFileBased(std::string filenamePrefixToWrite,
-                                         std::string writeCompleteTokenFileName,
-                                         std::string filenamePrefixToRead,
-                                         std::string startReadingTokenFileName);
+  inline void combineThirdLevelFileBased(const std::string& filenamePrefixToWrite,
+                                         const std::string& writeCompleteTokenFileName,
+                                         const std::string& filenamePrefixToRead,
+                                         const std::string& startReadingTokenFileName);
 
   inline size_t pretendCombineThirdLevelForBroker(std::vector<long long> numDofsToCommunicate,
-                                         bool checkValues);
+                                                  bool checkValues);
 
   inline void pretendCombineThirdLevelForWorkers();
 
@@ -345,8 +345,8 @@ void ProcessManager::combineThirdLevel() {
   waitAllFinished();
 }
 
-void ProcessManager::combineThirdLevelFileBasedWrite(std::string filenamePrefixToWrite,
-                                                     std::string writeCompleteTokenFileName) {
+void ProcessManager::combineThirdLevelFileBasedWrite(
+    const std::string& filenamePrefixToWrite, const std::string& writeCompleteTokenFileName) {
   // first combine local and global
   combineSystemWide();
 
@@ -363,8 +363,8 @@ void ProcessManager::combineThirdLevelFileBasedWrite(std::string filenamePrefixT
   waitForPG(thirdLevelPGroup_);
 }
 
-void ProcessManager::combineThirdLevelFileBasedReadReduce(std::string filenamePrefixToRead,
-                                                          std::string startReadingTokenFileName) {
+void ProcessManager::combineThirdLevelFileBasedReadReduce(
+    const std::string& filenamePrefixToRead, const std::string& startReadingTokenFileName) {
   // integrate the solutions
   Stats::startEvent("manager combine read");
   // tell other pgroups to wait for the combination result
@@ -380,10 +380,10 @@ void ProcessManager::combineThirdLevelFileBasedReadReduce(std::string filenamePr
   Stats::stopEvent("manager combine read");
 }
 
-void ProcessManager::combineThirdLevelFileBased(std::string filenamePrefixToWrite,
-                                                std::string writeCompleteTokenFileName,
-                                                std::string filenamePrefixToRead,
-                                                std::string startReadingTokenFileName) {
+void ProcessManager::combineThirdLevelFileBased(const std::string& filenamePrefixToWrite,
+                                                const std::string& writeCompleteTokenFileName,
+                                                const std::string& filenamePrefixToRead,
+                                                const std::string& startReadingTokenFileName) {
   // first combine local and global
   combineSystemWide();
 

--- a/src/manager/SparseGridWorker.hpp
+++ b/src/manager/SparseGridWorker.hpp
@@ -373,12 +373,9 @@ inline void SparseGridWorker::distributeChunkedBroadcasts(uint32_t maxMiBToSendP
         dsg->allocateDifferentSubspaces(std::move(subspaceChunk));
         this->copyFromExtraDsgToPartialDSG(0);
         // distribute (sg -> fg, within rank)
-        size_t totalNumCopied = 0;
         for (auto& taskToUpdate : this->taskWorkerRef_.getTasks()) {
-          totalNumCopied +=
-              taskToUpdate->getDistributedFullGrid(0).extractFromUniformSG<false>(*dsg);
+          taskToUpdate->getDistributedFullGrid(0).extractFromUniformSG<false>(*dsg);
         }
-        assert(totalNumCopied > 0);
         ++roundNumber;
       }
     }

--- a/src/sparsegrid/DistributedSparseGridIO.hpp
+++ b/src/sparsegrid/DistributedSparseGridIO.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <filesystem>
+#include <fstream>
 #include <string>
 
 #include "io/MPIInputOutput.hpp"
@@ -74,7 +76,7 @@ inline void writeMinMaxCoefficents(SparseGridType& dsg, const std::string& filen
 }
 
 template <typename SparseGridType>
-void writeToDiskChunked(const SparseGridType& dsg, std::string filePrefix) {
+void writeToDiskChunked(const SparseGridType& dsg, const std::string& filePrefix) {
   std::string myFilename = filePrefix + std::to_string(dsg.getRank());
   std::ofstream ofp(myFilename, std::ios::out | std::ios::binary);
   ofp.write(reinterpret_cast<const char*>(dsg.getRawData()),
@@ -83,8 +85,11 @@ void writeToDiskChunked(const SparseGridType& dsg, std::string filePrefix) {
 }
 
 template <typename SparseGridType>
-void readFromDiskChunked(SparseGridType& dsg, std::string filePrefix) {
+void readFromDiskChunked(SparseGridType& dsg, const std::string& filePrefix) {
   std::string myFilename = filePrefix + std::to_string(dsg.getRank());
+  // assert that file is large enough
+  [[maybe_unused]] size_t fileSize = std::filesystem::file_size(myFilename);
+  assert(fileSize == dsg.getRawDataSize() * sizeof(typename SparseGridType::ElementType));
   std::ifstream ifp(myFilename, std::ios::in | std::ios::binary);
   ifp.read(reinterpret_cast<char*>(dsg.getRawData()),
            dsg.getRawDataSize() * sizeof(typename SparseGridType::ElementType));

--- a/src/sparsegrid/DistributedSparseGridIO.hpp
+++ b/src/sparsegrid/DistributedSparseGridIO.hpp
@@ -221,5 +221,22 @@ int readReduceSubspaceSizesFromFile(SparseGridType& dsg, const std::string& file
 
   return numReduced;
 }
+
+template <typename SparseGridType, typename ReduceFunctionType>
+int readReduceSubspaceSizesFromFiles(SparseGridType& dsg, const std::vector<std::string>& fileNames,
+                                     ReduceFunctionType reduceFunction, int numElementsToBuffer = 0,
+                                     bool withCollectiveBuffering = false) {
+  auto comm = dsg.getCommunicator();
+  MPI_Offset len = dsg.getNumSubspaces();
+  if (numElementsToBuffer == 0) {
+    numElementsToBuffer = len;
+  }
+
+  int numReduced = mpiio::readMultipleReduceValuesConsecutive<SubspaceSizeType>(
+      dsg.getSubspaceDataSizes().data(), len, fileNames, comm, numElementsToBuffer, reduceFunction,
+      withCollectiveBuffering);
+
+  return numReduced;
+}
 }  // namespace DistributedSparseGridIO
 }  // namespace combigrid

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -32,6 +32,13 @@ using namespace combigrid;
 BOOST_CLASS_EXPORT(TaskConstParaboloid)
 BOOST_CLASS_EXPORT(TaskCount)
 
+#define CHECK_NO_THROW_LOUD(statement)                \
+  BOOST_CHECK_NO_THROW(                               \
+      try { statement; } catch (std::exception & e) { \
+        std::cout << e.what() << std::endl;           \
+        throw e;                                      \
+      })
+
 class TestParams {
  public:
   DimType dim = 2;
@@ -1040,14 +1047,7 @@ BOOST_AUTO_TEST_CASE(test_workers_only, *boost::unit_test::tolerance(TestHelper:
               std::cout << "third level worker only " << boundary << " " << ngroup << "*" << nprocs
                         << std::endl;
             }
-            BOOST_CHECK_NO_THROW(
-                try {
-                  testCombineThirdLevelWithoutManagers(testParams);
-                } catch (std::exception& e) {
-                  std::cout << "exception: " << e.what() << std::endl;
-                  throw e;
-                }
-            );
+            CHECK_NO_THROW_LOUD(testCombineThirdLevelWithoutManagers(testParams));
             MPI_Barrier(newcomm);
             BOOST_TEST_CHECKPOINT("sysNum " + std::to_string(sysNum) + " finished");
           }
@@ -1134,13 +1134,7 @@ BOOST_AUTO_TEST_CASE(test_workers_2d, *boost::unit_test::tolerance(TestHelper::t
       if (newcomm != MPI_COMM_NULL) {  // remove unnecessary procs
         TestParams testParams(dim, lmin, lmax, boundary, ngroup, nprocs, ncombi, sysNum, newcomm);
         BOOST_TEST_MESSAGE("test_workers_small: " + std::to_string(variant));
-        BOOST_CHECK_NO_THROW(
-            try {
-              testCombineThirdLevelWithoutManagers(testParams, variant);
-            } catch (std::exception& e) {
-              std::cout << "exception: " << e.what() << std::endl;
-              throw e;
-            });
+        CHECK_NO_THROW_LOUD(testCombineThirdLevelWithoutManagers(testParams, variant));
       }
       MPI_Barrier(MPI_COMM_WORLD);
     }
@@ -1173,13 +1167,7 @@ BOOST_AUTO_TEST_CASE(test_8_workers, *boost::unit_test::tolerance(TestHelper::to
       if (newcomm != MPI_COMM_NULL) {  // remove unnecessary procs
         TestParams testParams(dim, lmin, lmax, boundary, ngroup, nprocs, ncombi, sysNum, newcomm);
         BOOST_TEST_MESSAGE("test_8_workers: " + std::to_string(variant));
-        BOOST_CHECK_NO_THROW(
-            try {
-              testCombineThirdLevelWithoutManagers(testParams, variant);
-            } catch (std::exception& e) {
-              std::cout << "exception: " << e.what() << std::endl;
-              throw e;
-            });
+        CHECK_NO_THROW_LOUD(testCombineThirdLevelWithoutManagers(testParams, variant));
       }
       MPI_Barrier(MPI_COMM_WORLD);
     }
@@ -1206,13 +1194,7 @@ BOOST_AUTO_TEST_CASE(test_workers_three_systems_2d,
       TestParams testParams(dim, lmin, lmax, boundary, ngroup, nprocs, ncombi, sysNum, newcomm,
                             numSystems);
       BOOST_TEST_MESSAGE("test_workers_three_systems: " + std::to_string(variant));
-      BOOST_CHECK_NO_THROW(
-          try {
-            testCombineThirdLevelWithoutManagers(testParams, variant);
-          } catch (std::exception& e) {
-            std::cout << "exception: " << e.what() << std::endl;
-            throw e;
-          });
+      CHECK_NO_THROW_LOUD(testCombineThirdLevelWithoutManagers(testParams, variant));
     }
     MPI_Barrier(MPI_COMM_WORLD);
   }
@@ -1238,13 +1220,7 @@ BOOST_AUTO_TEST_CASE(test_workers_three_systems_6d,
       TestParams testParams(dim, lmin, lmax, boundary, ngroup, nprocs, ncombi, sysNum, newcomm,
                             numSystems);
       BOOST_TEST_MESSAGE("test_workers_three_systems: " + std::to_string(variant));
-      BOOST_CHECK_NO_THROW(
-          try {
-            testCombineThirdLevelWithoutManagers(testParams, variant);
-          } catch (std::exception& e) {
-            std::cout << "exception: " << e.what() << std::endl;
-            throw e;
-          });
+      CHECK_NO_THROW_LOUD(testCombineThirdLevelWithoutManagers(testParams, variant));
     }
     MPI_Barrier(MPI_COMM_WORLD);
   }

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -1133,11 +1133,16 @@ BOOST_AUTO_TEST_CASE(test_workers_2d, *boost::unit_test::tolerance(TestHelper::t
       if (newcomm != MPI_COMM_NULL) {  // remove unnecessary procs
         TestParams testParams(dim, lmin, lmax, boundary, ngroup, nprocs, ncombi, sysNum, newcomm);
         BOOST_TEST_MESSAGE("test_workers_small: " + std::to_string(variant));
-        BOOST_CHECK_NO_THROW(testCombineThirdLevelWithoutManagers(testParams, variant));
+        BOOST_CHECK_NO_THROW(
+            try {
+              testCombineThirdLevelWithoutManagers(testParams, variant);
+            } catch (std::exception& e) {
+              std::cout << "exception: " << e.what() << std::endl;
+              throw e;
+            });
       }
+      MPI_Barrier(MPI_COMM_WORLD);
     }
-
-    MPI_Barrier(MPI_COMM_WORLD);
   }
 }
 
@@ -1175,9 +1180,8 @@ BOOST_AUTO_TEST_CASE(test_8_workers, *boost::unit_test::tolerance(TestHelper::to
               throw e;
             });
       }
+      MPI_Barrier(MPI_COMM_WORLD);
     }
-
-    MPI_Barrier(MPI_COMM_WORLD);
   }
 }
 

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -1186,7 +1186,7 @@ BOOST_AUTO_TEST_CASE(test_8_workers, *boost::unit_test::tolerance(TestHelper::to
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_workers_three_systems,
+BOOST_AUTO_TEST_CASE(test_workers_three_systems_2d,
                      *boost::unit_test::tolerance(TestHelper::tolerance) *
                          boost::unit_test::timeout(250)) {
   unsigned int numSystems = 3;
@@ -1195,6 +1195,38 @@ BOOST_AUTO_TEST_CASE(test_workers_three_systems,
   BoundaryType boundary = 1;
   LevelVector lmin(dim, 2);
   LevelVector lmax(dim, 9);
+
+  for (unsigned int ngroup : std::vector<unsigned int>({1, 2})) {
+    unsigned int nprocs = 2 / ngroup;
+    unsigned int sysNum;
+    CommunicatorType newcomm = MPI_COMM_NULL;
+    assignProcsToSystems(ngroup * nprocs, numSystems, sysNum, newcomm);
+    auto variant = CombinationVariant::chunkedOutgroupSparseGridReduce;
+    if (newcomm != MPI_COMM_NULL) {  // remove unnecessary procs
+      TestParams testParams(dim, lmin, lmax, boundary, ngroup, nprocs, ncombi, sysNum, newcomm,
+                            numSystems);
+      BOOST_TEST_MESSAGE("test_workers_three_systems: " + std::to_string(variant));
+      BOOST_CHECK_NO_THROW(
+          try {
+            testCombineThirdLevelWithoutManagers(testParams, variant);
+          } catch (std::exception& e) {
+            std::cout << "exception: " << e.what() << std::endl;
+            throw e;
+          });
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_workers_three_systems_6d,
+                     *boost::unit_test::tolerance(TestHelper::tolerance) *
+                         boost::unit_test::timeout(550)) {
+  unsigned int numSystems = 3;
+  unsigned int ncombi = 3;
+  DimType dim = 6;
+  BoundaryType boundary = 1;
+  LevelVector lmin(dim, 2);
+  LevelVector lmax(dim, 5);
 
   for (unsigned int ngroup : std::vector<unsigned int>({1, 2})) {
     unsigned int nprocs = 2 / ngroup;

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -716,9 +716,16 @@ void testCombineThirdLevelWithoutManagers(
     std::string writeSparseGridFile =
         "worker_sg_" + std::to_string(testParams.sysNum) + "_step_" + std::to_string(it);
     std::string writeSparseGridFileToken = writeSparseGridFile + "_token.txt";
-    std::string readSparseGridFile =
-        "worker_sg_" + std::to_string((testParams.sysNum + 1) % 2) + "_step_" + std::to_string(it);
-    std::string readSparseGridFileToken = readSparseGridFile + "_token.txt";
+    std::vector<std::string> readSparseGridFiles;
+    std::vector<std::string> readSparseGridFileTokens;
+
+    for (size_t i = 0; i < testParams.numSystems; ++i) {
+      if (i != testParams.sysNum) {
+        readSparseGridFiles.push_back("worker_sg_" + std::to_string(i) + "_step_" +
+                                      std::to_string(it));
+        readSparseGridFileTokens.push_back(readSparseGridFiles.back() + "_token.txt");
+      }
+    }
     BOOST_TEST_CHECKPOINT("combine system-wide");
     start = std::chrono::high_resolution_clock::now();
     worker.combineSystemWideAndWrite(writeSparseGridFile, writeSparseGridFileToken);
@@ -727,7 +734,7 @@ void testCombineThirdLevelWithoutManagers(
     Stats::writePartial("stats_thirdLevel_worker_" + std::to_string(testParams.sysNum) + ".json",
                         theMPISystem()->getWorldComm());
     BOOST_TEST_CHECKPOINT("combine read/reduce");
-    worker.combineReadDistributeSystemWide(readSparseGridFile, readSparseGridFileToken, false,
+    worker.combineReadDistributeSystemWide(readSparseGridFiles, readSparseGridFileTokens, false,
                                            false);
 
     end = std::chrono::high_resolution_clock::now();

--- a/tests/test_thirdLevel.cpp
+++ b/tests/test_thirdLevel.cpp
@@ -42,13 +42,15 @@ class TestParams {
   unsigned int nprocs = 1;
   unsigned int ncombi = 1;
   unsigned int sysNum = 0;
+  unsigned int numSystems = 2;
   const CommunicatorType& comm;
   std::string host = "localhost";
   unsigned short port = 9999;
 
-  TestParams(DimType dim, LevelVector& lmin, LevelVector& lmax, BoundaryType boundary, unsigned int ngroup,
-             unsigned int nprocs, unsigned int ncombi, unsigned int sysNum,
-             const CommunicatorType& comm, const std::string& host = "localhost",
+  TestParams(DimType dim, LevelVector& lmin, LevelVector& lmax, BoundaryType boundary,
+             unsigned int ngroup, unsigned int nprocs, unsigned int ncombi, unsigned int sysNum,
+             const CommunicatorType& comm, unsigned int numSystems = 2,
+             const std::string& host = "localhost",
 #ifdef NDEBUG
              unsigned short dataPort = 9999)
 #else
@@ -62,6 +64,7 @@ class TestParams {
         nprocs(nprocs),
         ncombi(ncombi),
         sysNum(sysNum),
+        numSystems(numSystems),
         comm(comm),
         host(host),
         port(dataPort) {

--- a/tests/test_worker_only.cpp
+++ b/tests/test_worker_only.cpp
@@ -111,7 +111,7 @@ void checkWorkerOnly(size_t ngroup = 1, size_t nprocs = 1, BoundaryType boundary
     std::string subspaceSizeFileToken = "worker_only_subspace_sizes_token.txt";
     BOOST_TEST_CHECKPOINT("reduce sparse grid sizes");
     worker.reduceExtraSubspaceSizesFileBased(subspaceSizeFile, subspaceSizeFileToken,
-                                             subspaceSizeFile, subspaceSizeFileToken);
+                                             {subspaceSizeFile}, {subspaceSizeFileToken});
     // remove subspace size files to avoid interference between multiple calls to this test function
     BOOST_TEST_CHECKPOINT("reduced sparse grid sizes");
     MPI_Barrier(comm);

--- a/tests/test_worker_only.cpp
+++ b/tests/test_worker_only.cpp
@@ -165,7 +165,7 @@ void checkWorkerOnly(size_t ngroup = 1, size_t nprocs = 1, BoundaryType boundary
     std::string writeSparseGridFileToken = writeSparseGridFile + "_token.txt";
     worker.combineSystemWideAndWrite(writeSparseGridFile, writeSparseGridFileToken);
     BOOST_TEST_CHECKPOINT("worker read distribute system-wide");
-    worker.combineReadDistributeSystemWide(writeSparseGridFile, writeSparseGridFileToken, true);
+    worker.combineReadDistributeSystemWide({writeSparseGridFile}, {writeSparseGridFileToken}, true);
   } else {
     worker.combineAtOnce();
   }

--- a/tools/subspace_writer/subspace_writer.cpp
+++ b/tools/subspace_writer/subspace_writer.cpp
@@ -119,9 +119,6 @@ int main(int argc, char** argv) {
                   &new_communicator);
   theMPISystem()->storeLocalComm(new_communicator);
 
-  std::string firstSubspaceFileName =
-      ctschemeFile.substr(0, ctschemeFile.length() - std::string("_00008groups.json").length()) +
-      ".sizes";
   std::string conjointSubspaceFileName =
       ctschemeFile.substr(0,
                           ctschemeFile.length() - std::string("_part0_00008groups.json").length()) +
@@ -171,7 +168,7 @@ int main(int argc, char** argv) {
       int numUniDSGsWithSubspaceSet = 0;
       for (const auto& uniDSG : uniDSGs) {
         auto thisUniDSGsSize = uniDSG->getSubspaceDataSizes()[i];
-        assert(thisUniDSGsSize == 0 || thisUniDSGsSize == 8);
+        assert(thisUniDSGsSize == 0 || size == 0 || thisUniDSGsSize == size);
         if (thisUniDSGsSize > 0) {
           ++numUniDSGsWithSubspaceSet;
           size = thisUniDSGsSize;

--- a/tools/subspace_writer/subspace_writer.cpp
+++ b/tools/subspace_writer/subspace_writer.cpp
@@ -15,6 +15,42 @@
 
 using namespace combigrid;
 
+DistributedSparseGridUniform<CombiDataType>* schemeFileToSparseGridAndSizesFile(
+    const std::string& schemeFileName, DimType dim, const LevelVector& lmin,
+    const LevelVector& lmax, const LevelVector& reducedLmax,
+    const std::vector<BoundaryType>& boundary, const std::vector<int>& p,
+    const LevelVectorList& decomposition) {
+  // read in the scheme
+  std::unique_ptr<CombiMinMaxSchemeFromFile> scheme(
+      new CombiMinMaxSchemeFromFile(dim, lmin, lmax, schemeFileName));
+  const auto& allLevels = scheme->getCombiSpaces();
+
+  // create sparse grid
+  auto uniDSG = new DistributedSparseGridUniform<CombiDataType>(dim, reducedLmax, lmin,
+                                                                theMPISystem()->getLocalComm());
+
+  // register levels from other CT scheme
+  for (const auto& l : allLevels) {
+    auto dfgDecomposition = combigrid::downsampleDecomposition(decomposition, lmax, l, boundary);
+    auto uniDFG = std::unique_ptr<OwningDistributedFullGrid<CombiDataType>>(
+        new OwningDistributedFullGrid<CombiDataType>(dim, l, theMPISystem()->getLocalComm(),
+                                                     boundary, p, false, dfgDecomposition));
+    // MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "registering " << l << std::endl;
+    uniDSG->registerDistributedFullGrid(*uniDFG);
+  }
+  auto numDOF = std::accumulate(uniDSG->getSubspaceDataSizes().begin(),
+                                uniDSG->getSubspaceDataSizes().end(), 0);
+  MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "other sparse grid has " << numDOF
+                                             << " DOF per rank, which is " << numDOF * 8. / 1e9
+                                             << " GB" << std::endl;
+  // write the resulting sparse grid sizes to file
+  DistributedSparseGridIO::writeSubspaceSizesToFile(
+      *uniDSG, schemeFileName.substr(
+                   0, schemeFileName.length() - std::string("_00008groups.json").length()) +
+                   ".sizes");
+  return uniDSG;
+}
+
 int main(int argc, char** argv) {
   [[maybe_unused]] auto mpiOnOff = MpiOnOff(&argc, &argv);
   combigrid::Stats::initialize();
@@ -41,7 +77,8 @@ int main(int argc, char** argv) {
   cfg.get<std::string>("ct.p") >> p;
   std::string ctschemeFile = cfg.get<std::string>("ct.ctscheme");
   std::string otherCtschemeFile = cfg.get<std::string>("subspace.otherctscheme", "");
-  auto divide = cfg.get<DimType>("subspace.divide", 1);
+  std::string thirdCtschemeFile = cfg.get<std::string>("subspace.thirdctscheme", "");
+  DimType numSystems = cfg.get<DimType>("thirdLevel.numSystems", 2);
 
   // periodic boundary conditions
   std::vector<BoundaryType> boundary(dim, 1);
@@ -96,31 +133,13 @@ int main(int argc, char** argv) {
     const auto& allLevels = scheme->getCombiSpaces();
 
     // generate distributed sparse grid
-    auto uniDSG = std::unique_ptr<DistributedSparseGridUniform<CombiDataType>>(
-        new DistributedSparseGridUniform<CombiDataType>(dim, reducedLmax, lmin,
-                                                        theMPISystem()->getLocalComm()));
+    auto uniDSG = std::unique_ptr<DistributedSparseGridUniform<CombiDataType>>(schemeFileToSparseGridAndSizesFile(
+        ctschemeFile, dim, lmin, lmax, reducedLmax, boundary, p, decomposition));
+
     MIDDLE_PROCESS_EXCLUSIVE_SECTION {
       std::cout << "sparse grid contains " << uniDSG->getNumSubspaces() << " subspaces."
                 << std::endl;
     }
-
-    // register all component grid levels in this sparse grid
-    CombiDataType fakeData;
-    for (const auto& l : allLevels) {
-      auto dfgDecomposition = combigrid::downsampleDecomposition(decomposition, lmax, l, boundary);
-      auto uniDFG = std::unique_ptr<DistributedFullGrid<CombiDataType>>(
-          new DistributedFullGrid<CombiDataType>(dim, l, theMPISystem()->getLocalComm(), boundary,
-                                                 &fakeData, p, false, dfgDecomposition));
-      // MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "registering " << l << std::endl;
-      uniDSG->registerDistributedFullGrid(*uniDFG);
-    }
-    auto numDOF = std::accumulate(uniDSG->getSubspaceDataSizes().begin(),
-                                  uniDSG->getSubspaceDataSizes().end(), 0);
-    MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout
-        << "sparse grid has " << numDOF << " DOF per rank, which is " << numDOF * 8. / 1e9 << " GB"
-        << std::endl;
-    // write the resulting sparse grid sizes to file
-    DistributedSparseGridIO::writeSubspaceSizesToFile(*uniDSG, firstSubspaceFileName);
   }
   if (otherCtschemeFile == "") {
     // we are done already
@@ -129,50 +148,16 @@ int main(int argc, char** argv) {
   }
   {
     // read in second CT scheme
-    std::unique_ptr<CombiMinMaxSchemeFromFile> scheme(
-        new CombiMinMaxSchemeFromFile(dim, lmin, lmax, otherCtschemeFile));
-    const auto& allLevels = scheme->getCombiSpaces();
+    auto uniDSGOther = std::unique_ptr<DistributedSparseGridUniform<CombiDataType>>(
+        schemeFileToSparseGridAndSizesFile(otherCtschemeFile, dim, lmin, lmax, reducedLmax,
+                                           boundary, p, decomposition));
 
-    // another sparse grid
-    auto uniDSG = std::unique_ptr<DistributedSparseGridUniform<CombiDataType>>(
-        new DistributedSparseGridUniform<CombiDataType>(dim, reducedLmax, lmin,
-                                                        theMPISystem()->getLocalComm()));
-
-    // register levels from other CT scheme
-    for (const auto& l : allLevels) {
-      auto dfgDecomposition = combigrid::downsampleDecomposition(decomposition, lmax, l, boundary);
-      auto uniDFG = std::unique_ptr<OwningDistributedFullGrid<CombiDataType>>(
-          new OwningDistributedFullGrid<CombiDataType>(dim, l, theMPISystem()->getLocalComm(), boundary,
-                                                 p, false, dfgDecomposition));
-      // MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "registering " << l << std::endl;
-      uniDSG->registerDistributedFullGrid(*uniDFG);
-    }
-    auto numDOF = std::accumulate(uniDSG->getSubspaceDataSizes().begin(),
-                                  uniDSG->getSubspaceDataSizes().end(), 0);
-    MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "other sparse grid has " << numDOF
-                                               << " DOF per rank, which is " << numDOF * 8. / 1e9
-                                               << " GB" << std::endl;
-    // write the resulting sparse grid sizes to file
-    DistributedSparseGridIO::writeSubspaceSizesToFile(
-        *uniDSG, otherCtschemeFile.substr(
-                     0, otherCtschemeFile.length() - std::string("_00008groups.json").length()) +
-                     ".sizes");
-
-    // read written sparse grid sizes from file
-    // for extra sparse grid / conjoint subspaces, min-reduce the sizes
-    auto minFunctionInstantiation = [](SubspaceSizeType a, SubspaceSizeType b) {
-      return std::min(a, b);
-    };
-    // use extra sparse grid
-    DistributedSparseGridIO::readReduceSubspaceSizesFromFile(*uniDSG, firstSubspaceFileName,
-                                                             minFunctionInstantiation);
-
-    auto numDOFconjoint = std::accumulate(uniDSG->getSubspaceDataSizes().begin(),
-                                          uniDSG->getSubspaceDataSizes().end(), 0);
+    auto numDOFconjoint = std::accumulate(uniDSGOther->getSubspaceDataSizes().begin(),
+                                          uniDSGOther->getSubspaceDataSizes().end(), 0);
     MIDDLE_PROCESS_EXCLUSIVE_SECTION std::cout << "conjoint sparse grid has " << numDOFconjoint
                                                << " DOF per rank" << std::endl;
     // write final sizes to file
-    DistributedSparseGridIO::writeSubspaceSizesToFile(*uniDSG, conjointSubspaceFileName);
+    DistributedSparseGridIO::writeSubspaceSizesToFile(*uniDSGOther, conjointSubspaceFileName);
 
     // output first rank's sizes
   }


### PR DESCRIPTION
This PR adapts the functions for file-based combination for three systems 
(where easily possible, for arbitrary numbers of systems).
It is assumed that Outgroup Sparse Grid Reduce is used for the widely-distributed combination (so each system has to write only one file, which is then copied to all other systems).