### PR TITLE
Jenkinsfile: update spack syntax

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -148,8 +148,11 @@ pipeline {
                                     dir("DisCoTec-${compiler}-${mpiimpl}-${build_type}") {
                                         sh '''
                                             . ../discotec-spack/spack/share/spack/setup-env.sh
-                                            spack load --only dependencies --first discotec@main -lto %${compiler} ^${mpiimpl} #+selalib
+                                            spack load --first ${mpiimpl} %${compiler}
                                             spack load --first cmake %${compiler}
+                                            spack load --first boost %${compiler}
+                                            spack load --first glpk %${compiler}
+                                            spack load --first highfive %${compiler}
                                             spack load --first lz4 %${compiler}
                                             mkdir -p build/${compiler}-${mpiimpl}-${build_type}
                                             cd build/${compiler}-${mpiimpl}-${build_type}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -169,7 +169,9 @@ pipeline {
                             dir("DisCoTec-${compiler}-${mpiimpl}-${build_type}") {
                                 sh '''
                                     . ../discotec-spack/spack/share/spack/setup-env.sh
-                                    spack load --only dependencies --first discotec@main -lto %${compiler} ^${mpiimpl} #+selalib
+                                    spack load --first ${mpiimpl} %${compiler}
+                                    spack load --first boost %${compiler}
+                                    spack load --first highfive %${compiler}
                                     export OMP_NUM_THREADS=4
                                     cd tests/
                                     mpiexec.${mpiimpl} -n 9 ./test_distributedcombigrid_boost --run_test=mpisystem                      
@@ -186,7 +188,9 @@ pipeline {
                                 dir("DisCoTec-${compiler}-${mpiimpl}-${build_type}") {
                                     sh '''
                                         . ../discotec-spack/spack/share/spack/setup-env.sh
-                                        spack load --only dependencies --first discotec@main -lto %${compiler} ^${mpiimpl} #+selalib
+                                        spack load --first ${mpiimpl} %${compiler}
+                                        spack load --first boost %${compiler}
+                                        spack load --first highfive %${compiler}
                                         export OMP_NUM_THREADS=4
                                         cd tests/
                                         mpiexec.${mpiimpl} -n 9 ./test_distributedcombigrid_boost --run_test=integration
@@ -206,7 +210,9 @@ pipeline {
                                         if (compiler == 'gcc' && mpiimpl == 'openmpi') { // execute third-level test only for one compiler set
                                             sh '''
                                                 . ../discotec-spack/spack/share/spack/setup-env.sh
-                                                spack load --only dependencies --first discotec@main -lto %${compiler} ^${mpiimpl} #+selalib
+                                                spack load --first ${mpiimpl} %${compiler}
+                                                spack load --first boost %${compiler}
+                                                spack load --first highfive %${compiler}
                                                 export OMP_NUM_THREADS=4
                                                 cd tests/                   
                                                 mpiexec.${mpiimpl} -n 9 ./test_distributedcombigrid_boost --run_test=thirdLevel/test_workers_only,test_workers_2d,test_8_workers  # file-based exchange needs to execute correctly

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
                                             spack load --first cmake %${compiler}
                                             spack load --first boost %${compiler}
                                             spack load --first glpk %${compiler}
-                                            spack load --first highfive %${compiler}
+                                            spack load --first highfive %${compiler} ^${mpiimpl}
                                             spack load --first lz4 %${compiler}
                                             mkdir -p build/${compiler}-${mpiimpl}-${build_type}
                                             cd build/${compiler}-${mpiimpl}-${build_type}
@@ -171,7 +171,7 @@ pipeline {
                                     . ../discotec-spack/spack/share/spack/setup-env.sh
                                     spack load --first ${mpiimpl} %${compiler}
                                     spack load --first boost %${compiler}
-                                    spack load --first highfive %${compiler}
+                                    spack load --first highfive %${compiler} ^${mpiimpl}
                                     export OMP_NUM_THREADS=4
                                     cd tests/
                                     mpiexec.${mpiimpl} -n 9 ./test_distributedcombigrid_boost --run_test=mpisystem                      
@@ -190,7 +190,7 @@ pipeline {
                                         . ../discotec-spack/spack/share/spack/setup-env.sh
                                         spack load --first ${mpiimpl} %${compiler}
                                         spack load --first boost %${compiler}
-                                        spack load --first highfive %${compiler}
+                                        spack load --first highfive %${compiler} ^${mpiimpl}
                                         export OMP_NUM_THREADS=4
                                         cd tests/
                                         mpiexec.${mpiimpl} -n 9 ./test_distributedcombigrid_boost --run_test=integration
@@ -212,7 +212,7 @@ pipeline {
                                                 . ../discotec-spack/spack/share/spack/setup-env.sh
                                                 spack load --first ${mpiimpl} %${compiler}
                                                 spack load --first boost %${compiler}
-                                                spack load --first highfive %${compiler}
+                                                spack load --first highfive %${compiler} ^${mpiimpl}
                                                 export OMP_NUM_THREADS=4
                                                 cd tests/                   
                                                 mpiexec.${mpiimpl} -n 9 ./test_distributedcombigrid_boost --run_test=thirdLevel/test_workers_only,test_workers_2d,test_8_workers  # file-based exchange needs to execute correctly


### PR DESCRIPTION
Apparently, the `spack load --only dependencies` command has been deprecated. Trying to explicitly load all run dependencies instead.