### PR TITLE
Fix selalib build error

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -80,8 +80,8 @@ pipeline {
                                         spack compiler find  
                                         # remove compilers with stl/linker/fortran issues
                                         spack compiler remove -a gcc@10.1.0: || true # ignore if this compiler was not found
-                                        spack spec -y discotec@main -lto %${compiler} ^${mpiimpl} +selalib # --only dependencies # actually build discotec, such that load command will work
-                                        spack install -y discotec@main -lto %${compiler} ^${mpiimpl} +selalib # --only dependencies # actually build discotec, such that load command will work
+                                        spack spec -y discotec@main -lto +selalib %${compiler} ^${mpiimpl} # --only dependencies # actually build discotec, such that load command will work
+                                        spack install -y discotec@main -lto +selalib %${compiler} ^${mpiimpl} # --only dependencies # actually build discotec, such that load command will work
                                         spack install -y lz4 %${compiler}
                                         '''
                                     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -80,12 +80,12 @@ pipeline {
                                         spack compiler find  
                                         # remove compilers with stl/linker/fortran issues
                                         spack compiler remove -a gcc@10.1.0: || true # ignore if this compiler was not found
-                                        # cf. error w/ hdf5 installation, dependency of selalib
+                                        # cf. error w/ hdf5, during selalib build: The link interface of target "hdf5-static" contains: ZLIB::ZLIB but the target was not found.
                                         # https://forum.hdfgroup.org/t/cmake-zlib-dependency-not-properly-propagted-by-hdf5-targets/5149
-                                        spack install zlib
-                                        spack load zlib
-                                        spack spec -y discotec@main -lto +selalib %${compiler} ^${mpiimpl} # --only dependencies # actually build discotec, such that load command will work
-                                        spack install -y discotec@main -lto +selalib %${compiler} ^${mpiimpl} # --only dependencies # actually build discotec, such that load command will work
+                                        # spack install zlib
+                                        # spack load zlib
+                                        spack spec -y discotec@main -lto %${compiler} ^${mpiimpl} # +selalib # --only dependencies # actually build discotec, such that load command will work
+                                        spack install -y discotec@main -lto %${compiler} ^${mpiimpl} # +selalib # --only dependencies # actually build discotec, such that load command will work
                                         spack install -y lz4 %${compiler}
                                         '''
                                     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -80,6 +80,10 @@ pipeline {
                                         spack compiler find  
                                         # remove compilers with stl/linker/fortran issues
                                         spack compiler remove -a gcc@10.1.0: || true # ignore if this compiler was not found
+                                        # cf. error w/ hdf5 installation, dependency of selalib
+                                        # https://forum.hdfgroup.org/t/cmake-zlib-dependency-not-properly-propagted-by-hdf5-targets/5149
+                                        spack install zlib
+                                        spack load zlib
                                         spack spec -y discotec@main -lto +selalib %${compiler} ^${mpiimpl} # --only dependencies # actually build discotec, such that load command will work
                                         spack install -y discotec@main -lto +selalib %${compiler} ^${mpiimpl} # --only dependencies # actually build discotec, such that load command will work
                                         spack install -y lz4 %${compiler}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -80,8 +80,8 @@ pipeline {
                                         spack compiler find  
                                         # remove compilers with stl/linker/fortran issues
                                         spack compiler remove -a gcc@10.1.0: || true # ignore if this compiler was not found
-                                        spack spec -y discotec@main -lto %${compiler} ^${mpiimpl} #+selalib # --only dependencies # actually build discotec, such that load command will work
-                                        spack install -y discotec@main -lto %${compiler} ^${mpiimpl} #+selalib # --only dependencies # actually build discotec, such that load command will work
+                                        spack spec -y discotec@main -lto %${compiler} ^${mpiimpl} +selalib # --only dependencies # actually build discotec, such that load command will work
+                                        spack install -y discotec@main -lto %${compiler} ^${mpiimpl} +selalib # --only dependencies # actually build discotec, such that load command will work
                                         spack install -y lz4 %${compiler}
                                         '''
                                     }

--- a/examples/selalib_distributed/postprocessing/combine_selalib_phi.cpp
+++ b/examples/selalib_distributed/postprocessing/combine_selalib_phi.cpp
@@ -59,8 +59,10 @@ int main(int argc, char** argv) {
   MPI_Cart_create(MPI_COMM_SELF, 3, new int[3]{1, 1, 1}, new int[3]{1, 1, 1}, 1, &commSelfPeriodic);
 
   for (const auto& df : diagnosticsFiles) {
-    combigrid::OwningDistributedFullGrid<double> combinedFullGrid(dim_x, lmax_x, commSelfPeriodic, {1, 1, 1}, {1, 1, 1}, false);
-    combigrid::DistributedSparseGridUniform<double> combinedSparseGrid(dim_x, lmax_x, lmin_x, commSelfPeriodic);
+    combigrid::OwningDistributedFullGrid<double> combinedFullGrid(dim_x, lmax_x, commSelfPeriodic,
+                                                                  {1, 1, 1}, {1, 1, 1}, false);
+    combigrid::DistributedSparseGridUniform<double> combinedSparseGrid(dim_x, lmax_x, lmin_x,
+                                                                       commSelfPeriodic);
     combinedSparseGrid.registerDistributedFullGrid(combinedFullGrid);
     combinedSparseGrid.createSubspaceData();
 
@@ -148,7 +150,8 @@ int main(int argc, char** argv) {
               << Stats::getDuration("dehierarchize") << " milliseconds" << std::endl;
 
     boost::const_multi_array_ref<double, 3> combinedValues =
-        combinedFullGrid.getTensor().getAsConstMultiArrayRef<3>();
+        boost::const_multi_array_ref<double, 3>(combinedFullGrid.getData(),
+                                                combinedFullGrid.getGlobalSizes());
     boost::multi_array<double, 3> combinedValuesCopy = combinedValues;
 
     // output interpolated values to h5 file

--- a/examples/selalib_distributed/template/param.nml
+++ b/examples/selalib_distributed/template/param.nml
@@ -43,7 +43,7 @@
 /
 
 &output
-       file_prefix = $name_diagnostics
+       file_prefix = "$name_diagnostics"
        time_in_phase = .true. ! get solution at final time exactly (perform half advection step)
 /
 


### PR DESCRIPTION
Fixes an error that occured with `spack dev-build discotec+selalib`, where `combine_selalib_phi` could not be built.

I tried to put the selalib build into the CI, but weird spack dependency problems keep HDF5 from building, so I reverted that.